### PR TITLE
Optimize loading file properties

### DIFF
--- a/projectBlueWater/projectBlueWater.iml
+++ b/projectBlueWater/projectBlueWater.iml
@@ -89,12 +89,14 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/apk_for_local_test" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/apk_list" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundle_dependency_report" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundle_manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check_manifest_result" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/compatible_screen_manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant_app_manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant_run_merged_manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/intermediary_bundle" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javac" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/linked_res_for_bundle" />
@@ -105,6 +107,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/merged_manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/merged_shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/metadata_feature_manifest" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/metadata_library_dependencies_report" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/module_bundle" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/prebuild" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/processed_res" />
@@ -239,6 +242,16 @@
     <orderEntry type="library" name="Gradle: com.android.support:support-media-compat:28.0.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.robolectric:shadowapi:4.1@jar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.robolectric:sandbox:4.1@jar" level="project" />
+    <orderEntry type="module" module-name="pagerslidingtabstrip" />
+    <orderEntry type="module" module-name="futures" />
+    <orderEntry type="module" module-name="pagerslidingtabstrip" />
+    <orderEntry type="module" module-name="futures" />
+    <orderEntry type="module" module-name="pagerslidingtabstrip" />
+    <orderEntry type="module" module-name="futures" />
+    <orderEntry type="module" module-name="pagerslidingtabstrip" />
+    <orderEntry type="module" module-name="futures" />
+    <orderEntry type="module" module-name="pagerslidingtabstrip" />
+    <orderEntry type="module" module-name="futures" />
     <orderEntry type="module" module-name="pagerslidingtabstrip" />
     <orderEntry type="module" module-name="futures" />
   </component>

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/library/items/media/files/menu/FileNameTextViewSetter.java
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/library/items/media/files/menu/FileNameTextViewSetter.java
@@ -25,7 +25,7 @@ public class FileNameTextViewSetter {
 	private final TextView textView;
 	private final Handler handler;
 
-	private Promise<Void> currentlyPromisedTextViewUpdate;
+	private volatile Promise<Void> currentlyPromisedTextViewUpdate;
 
 	public FileNameTextViewSetter(TextView textView) {
 		this.textView = textView;
@@ -36,17 +36,17 @@ public class FileNameTextViewSetter {
 		if (currentlyPromisedTextViewUpdate != null)
 			currentlyPromisedTextViewUpdate.cancel();
 
-		return currentlyPromisedTextViewUpdate = new LockedTextViewOperator(textView, handler, serviceFile);
+		return currentlyPromisedTextViewUpdate = new PromisedTextViewUpdate(textView, handler, serviceFile);
 	}
 
-	private class LockedTextViewOperator extends Promise<Void> implements Runnable {
+	private class PromisedTextViewUpdate extends Promise<Void> implements Runnable {
 
 		private final CancellationProxy cancellationProxy = new CancellationProxy();
 		private final TextView textView;
 		private final Handler handler;
 		private final ServiceFile serviceFile;
 
-		LockedTextViewOperator(TextView textView, Handler handler, ServiceFile serviceFile) {
+		PromisedTextViewUpdate(TextView textView, Handler handler, ServiceFile serviceFile) {
 			this.textView = textView;
 			this.handler = handler;
 			this.serviceFile = serviceFile;

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/library/items/media/files/menu/FileNameTextViewSetter.java
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/library/items/media/files/menu/FileNameTextViewSetter.java
@@ -15,7 +15,7 @@ import com.namehillsoftware.handoff.promises.propagation.CancellationProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 
@@ -68,7 +68,7 @@ public class FileNameTextViewSetter {
 				.eventually(connectionProvider -> {
 					if (isUpdateCancelled()) {
 						resolve(null);
-						return new Promise<>(new HashMap<>());
+						return new Promise<>(Collections.emptyMap());
 					}
 
 					final FilePropertyCache filePropertyCache = FilePropertyCache.getInstance();


### PR DESCRIPTION
When loading a list of files, for each promised file property, compare a reference to the current promised return of files to itself to see if it is still the current promise, and if so, update the textview with the new file name.