### PR TITLE
Bugfix: Ignore exceptions when file updates are canceled

### DIFF
--- a/projectBlueWater/projectBlueWater.iml
+++ b/projectBlueWater/projectBlueWater.iml
@@ -244,5 +244,7 @@
     <orderEntry type="library" scope="TEST" name="Gradle: org.robolectric:sandbox:4.1@jar" level="project" />
     <orderEntry type="module" module-name="pagerslidingtabstrip" />
     <orderEntry type="module" module-name="futures" />
+    <orderEntry type="module" module-name="pagerslidingtabstrip" />
+    <orderEntry type="module" module-name="futures" />
   </component>
 </module>

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/library/items/media/files/list/AbstractFileListAdapter.java
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/library/items/media/files/list/AbstractFileListAdapter.java
@@ -8,15 +8,15 @@ import java.util.List;
 
 public abstract class AbstractFileListAdapter extends ArrayAdapter<ServiceFile> {
 
-	private final List<ServiceFile> mServiceFiles;
+	private final List<ServiceFile> serviceFiles;
 
 	protected AbstractFileListAdapter(Context context, int resource, List<ServiceFile> serviceFiles) {
 		super(context, resource, serviceFiles);
 		
-		mServiceFiles = serviceFiles;
+		this.serviceFiles = serviceFiles;
 	}
 
 	public final List<ServiceFile> getFiles() {
-		return mServiceFiles;
+		return serviceFiles;
 	}
 }


### PR DESCRIPTION
When populating a file list, ignore exceptions when the update to an item is canceled.