### PR TITLE
[Bugfix] Now Playing List Out of Date

### DIFF
--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/BrowserEntryActivity.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/BrowserEntryActivity.kt
@@ -40,7 +40,6 @@ import com.lasthopesoftware.bluewater.client.connection.selected.SelectedConnect
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.view.NowPlayingFloatingActionButton
 import com.lasthopesoftware.bluewater.client.stored.library.items.files.fragment.ActiveFileDownloadsFragment
 import com.lasthopesoftware.bluewater.settings.ApplicationSettingsActivity
-import com.lasthopesoftware.bluewater.settings.repository.access.CachingApplicationSettingsRepository.Companion.getApplicationSettingsRepository
 import com.lasthopesoftware.bluewater.shared.MagicPropertyBuilder
 import com.lasthopesoftware.bluewater.shared.android.view.LazyViewFinder
 import com.lasthopesoftware.bluewater.shared.android.view.ViewUtils
@@ -71,8 +70,6 @@ class BrowserEntryActivity : AppCompatActivity(), IItemListViewContainer, Runnab
 	private val selectedLibraryViews by lazy {
 		SelectedLibraryViewProvider(selectedBrowserLibraryProvider, libraryViewsProvider, libraryRepository)
 	}
-
-	private val applicationSettings by lazy { getApplicationSettingsRepository() }
 
 	private val selectedBrowserLibraryProvider by lazy { SelectedBrowserLibraryProvider(
 		getCachedSelectedLibraryIdProvider(),

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/library/access/ISpecificLibraryProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/library/access/ISpecificLibraryProvider.kt
@@ -3,9 +3,6 @@ package com.lasthopesoftware.bluewater.client.browsing.library.access
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.Library
 import com.namehillsoftware.handoff.promises.Promise
 
-/**
- * Created by david on 2/12/17.
- */
 interface ISpecificLibraryProvider {
-	val library: Promise<Library?>
+	fun promiseLibrary(): Promise<Library?>
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/library/access/SpecificLibraryProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/library/access/SpecificLibraryProvider.kt
@@ -8,6 +8,5 @@ import com.namehillsoftware.handoff.promises.Promise
  * Created by david on 2/12/17.
  */
 class SpecificLibraryProvider(private val libraryId: LibraryId, private val libraryProvider: ILibraryProvider) : ISpecificLibraryProvider {
-	override val library: Promise<Library?>
-		get() = libraryProvider.getLibrary(libraryId)
+    override fun promiseLibrary(): Promise<Library?> = libraryProvider.getLibrary(libraryId)
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/remote/RemoteBrowserService.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/remote/RemoteBrowserService.kt
@@ -25,6 +25,7 @@ import com.lasthopesoftware.bluewater.client.browsing.library.revisions.LibraryR
 import com.lasthopesoftware.bluewater.client.browsing.library.views.access.CachedLibraryViewsProvider
 import com.lasthopesoftware.bluewater.client.connection.session.ConnectionSessionManager
 import com.lasthopesoftware.bluewater.client.connection.session.ConnectionSessionManager.Instance.buildNewConnectionSessionManager
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.InMemoryNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.shared.MagicPropertyBuilder
 import com.lasthopesoftware.bluewater.shared.android.MediaSession.MediaSessionService
@@ -117,7 +118,8 @@ class RemoteBrowserService : MediaBrowserServiceCompat() {
 					val repository =
                         NowPlayingRepository(
                             SpecificLibraryProvider(l, libraryRepository),
-                            libraryRepository
+                            libraryRepository,
+							InMemoryNowPlayingState,
                         )
 
 					NowPlayingMediaItemLookup(

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/engine/PlaybackEngine.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/engine/PlaybackEngine.kt
@@ -86,7 +86,7 @@ class PlaybackEngine(
 		this.playlist = playlist.toMutableList()
 		this.playlistPosition = playlistPosition
 		this.fileProgress = StaticProgressedFile(filePosition.toPromise())
-		return saveState().then { resumePlayback() }
+		return saveState().eventually { resumePlayback() }
 	}
 
 	override fun skipToNext(): Promise<PositionedFile> {

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/HoldNowPlayingState.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/HoldNowPlayingState.kt
@@ -1,0 +1,9 @@
+package com.lasthopesoftware.bluewater.client.playback.nowplaying.storage
+
+import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
+
+interface HoldNowPlayingState {
+	operator fun set(libraryId: LibraryId, nowPlaying: NowPlaying)
+
+	operator fun get(libraryId: LibraryId): NowPlaying?
+}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/InMemoryNowPlayingState.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/InMemoryNowPlayingState.kt
@@ -1,0 +1,14 @@
+package com.lasthopesoftware.bluewater.client.playback.nowplaying.storage
+
+import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
+import java.util.concurrent.ConcurrentHashMap
+
+object InMemoryNowPlayingState : HoldNowPlayingState {
+	private val nowPlayingCache = ConcurrentHashMap<LibraryId, NowPlaying>()
+
+	override fun set(libraryId: LibraryId, nowPlaying: NowPlaying) {
+		nowPlayingCache[libraryId] = nowPlaying
+	}
+
+	override fun get(libraryId: LibraryId): NowPlaying? = nowPlayingCache[libraryId]
+}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/LiveNowPlayingLookup.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/LiveNowPlayingLookup.kt
@@ -79,7 +79,7 @@ class LiveNowPlayingLookup private constructor(
 				}
 
 				np?.let {
-					trackedPosition?.let(it::withFilePosition) ?: it
+					trackedPosition?.let { p -> it.copy(filePosition = p) } ?: it
 				}
 			}
 			.keepPromise()

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/LiveNowPlayingLookup.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/LiveNowPlayingLookup.kt
@@ -89,6 +89,7 @@ class LiveNowPlayingLookup private constructor(
 				promiseNowPlaying()
 					.then {
 						mutableNowPlayingState.set(it?.playingFile)
+						trackedPosition = it?.filePosition
 					}
 		}
 	}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/LiveNowPlayingLookup.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/LiveNowPlayingLookup.kt
@@ -85,7 +85,7 @@ class LiveNowPlayingLookup private constructor(
 			.keepPromise()
 
 	private fun updateInner(libraryId: LibraryId) {
-		inner = NowPlayingRepository(SpecificLibraryProvider(libraryId, libraryProvider), libraryStorage).apply {
+		inner = NowPlayingRepository(SpecificLibraryProvider(libraryId, libraryProvider), libraryStorage, InMemoryNowPlayingState).apply {
 				promiseNowPlaying()
 					.then {
 						mutableNowPlayingState.set(it?.playingFile)

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlaying.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlaying.kt
@@ -4,7 +4,7 @@ import com.lasthopesoftware.bluewater.client.browsing.files.ServiceFile
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
 
-class NowPlaying(
+data class NowPlaying(
 	val libraryId: LibraryId,
 	val playlist: List<ServiceFile>,
     val playlistPosition: Int,
@@ -15,15 +15,4 @@ class NowPlaying(
 	val playingFile: PositionedFile?
 		get() =
 			playlistPosition.takeIf { it > -1 && it < playlist.size }?.let { PositionedFile(it, playlist[it]) }
-
-	fun withFilePosition(filePosition: Long): NowPlaying = NowPlaying(
-		libraryId,
-		playlist,
-		playlistPosition,
-		filePosition,
-		isRepeating,
-	)
-
-    constructor(libraryId: LibraryId, playlistPosition: Int, filePosition: Long, isRepeating: Boolean)
-		: this(libraryId, emptyList(), playlistPosition, filePosition, isRepeating)
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingFileProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingFileProvider.kt
@@ -24,7 +24,8 @@ class NowPlayingFileProvider private constructor(private val nowPlayingRepositor
 						NowPlayingFileProvider(
 							NowPlayingRepository(
 								SpecificLibraryProvider(it, libraryRepository),
-								libraryRepository
+								libraryRepository,
+								InMemoryNowPlayingState,
 							)
 						)
 					}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingRepository.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingRepository.kt
@@ -28,7 +28,8 @@ class NowPlayingRepository(
 				.eventually { library ->
 					library?.run {
 						trackedLibraryId = id
-						savedTracksString
+						nowPlayingCache[id]?.toPromise()
+							?: savedTracksString
 							?.takeIf { it.isNotEmpty() }
 							?.let(::promiseParsedFileStringList)
 							?.then { files ->

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingRepository.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingRepository.kt
@@ -52,7 +52,6 @@ class NowPlayingRepository(
 
 	override fun updateNowPlaying(nowPlaying: NowPlaying): Promise<NowPlaying> {
 		return trackedLibraryId
-			?.also { holdNowPlayingState[it] = nowPlaying }
 			?.let {
 				holdNowPlayingState[it] = nowPlaying
 				libraryProvider.library

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingRepository.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/NowPlayingRepository.kt
@@ -20,8 +20,10 @@ class NowPlayingRepository(
 	private var trackedLibraryId: LibraryId? = null
 
 	override fun promiseNowPlaying(): Promise<NowPlaying?> =
-		trackedLibraryId?.let(holdNowPlayingState::get)?.toPromise()
-			?: libraryProvider.library
+		trackedLibraryId
+			?.let(holdNowPlayingState::get)?.toPromise()
+			?: libraryProvider
+				.promiseLibrary()
 				.eventually { library ->
 					library?.run {
 						trackedLibraryId = libraryId
@@ -50,11 +52,11 @@ class NowPlayingRepository(
 					}.keepPromise()
 				}
 
-	override fun updateNowPlaying(nowPlaying: NowPlaying): Promise<NowPlaying> {
-		return trackedLibraryId
+	override fun updateNowPlaying(nowPlaying: NowPlaying): Promise<NowPlaying> =
+		trackedLibraryId
 			?.let {
 				holdNowPlayingState[it] = nowPlaying
-				libraryProvider.library
+				libraryProvider.promiseLibrary()
 					.then { library ->
 						library?.apply {
 							setNowPlayingId(nowPlaying.playlistPosition)
@@ -70,5 +72,4 @@ class NowPlayingRepository(
 				nowPlaying.toPromise()
 			}
 			?: promiseNowPlaying().eventually { updateNowPlaying(nowPlaying) }
-	}
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/view/activity/fragments/playlist/NowPlayingPlaylistFragment.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/view/activity/fragments/playlist/NowPlayingPlaylistFragment.kt
@@ -247,10 +247,6 @@ class NowPlayingPlaylistFragment : Fragment() {
 		super.onDestroy()
 	}
 
-	fun setOnItemListMenuChangeHandler(itemListMenuChangeHandler: IItemListMenuChangeHandler?) {
-		this.itemListMenuChangeHandler = itemListMenuChangeHandler
-	}
-
 	private class NowPlayingDragCallback<ViewHolder : RecyclerView.ViewHolder?>(
 		private val context: Context,
 		private val adapter: DeferredListAdapter<PositionedFile, ViewHolder>,

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/view/activity/fragments/playlist/NowPlayingPlaylistFragment.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/view/activity/fragments/playlist/NowPlayingPlaylistFragment.kt
@@ -30,6 +30,7 @@ import com.lasthopesoftware.bluewater.client.connection.libraries.UrlKeyProvider
 import com.lasthopesoftware.bluewater.client.connection.polling.ConnectionPoller
 import com.lasthopesoftware.bluewater.client.connection.session.ConnectionSessionManager.Instance.buildNewConnectionSessionManager
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.InMemoryNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.LiveNowPlayingLookup
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.view.activity.viewmodels.InMemoryNowPlayingDisplaySettings
@@ -103,7 +104,8 @@ class NowPlayingPlaylistFragment : Fragment() {
 			.then { l ->
 				NowPlayingRepository(
 					SpecificLibraryProvider(l!!, libraryRepository),
-					libraryRepository
+					libraryRepository,
+					InMemoryNowPlayingState,
 				)
 			}
 	}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/view/activity/viewmodels/NowPlayingFilePropertiesViewModel.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/view/activity/viewmodels/NowPlayingFilePropertiesViewModel.kt
@@ -103,7 +103,6 @@ class NowPlayingFilePropertiesViewModel(
 	val nowPlayingFile = nowPlayingFileState.asStateFlow()
 	val isScreenControlsVisible = isScreenControlsVisibleState.asStateFlow()
 	val isRepeating = isRepeatingState.asStateFlow()
-	val unexpectedError = unexpectedErrorState.asStateFlow()
 
 	override fun onCleared() {
 		cachedPromises?.close()

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/service/PlaybackService.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/service/PlaybackService.kt
@@ -78,6 +78,7 @@ import com.lasthopesoftware.bluewater.client.playback.nowplaying.broadcasters.no
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.broadcasters.notification.building.NowPlayingNotificationBuilder
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.broadcasters.notification.building.PlaybackStartingNotificationBuilder
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.broadcasters.remote.MediaSessionBroadcaster
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.InMemoryNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.MaintainNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.view.activity.NowPlayingActivity.Companion.startNowPlayingActivity
@@ -443,7 +444,8 @@ open class PlaybackService :
 				l?.let {
                     NowPlayingRepository(
                         SpecificLibraryProvider(l, libraryRepository),
-                        libraryRepository
+                        libraryRepository,
+						InMemoryNowPlayingState,
                     )
 				}
 			}
@@ -702,7 +704,8 @@ open class PlaybackService :
 			val scopedUrlKeyProvider = ScopedUrlKeyProvider(connectionProvider)
 			val nowPlayingRepository = NowPlayingRepository(
 				SpecificLibraryProvider(library.libraryId, libraryRepository),
-				libraryRepository
+				libraryRepository,
+				InMemoryNowPlayingState,
 			)
 			val promisedMediaBroadcaster = promisedMediaSession.then { mediaSession ->
 				val broadcaster = MediaSessionBroadcaster(

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/observables/MaybeObservePromise.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/observables/MaybeObservePromise.kt
@@ -5,9 +5,9 @@ import io.reactivex.Maybe
 import io.reactivex.MaybeObserver
 import io.reactivex.disposables.Disposable
 
-fun <T> Promise<T>.toMaybeObservable(): Maybe<T> = MaybePromise(this)
+fun <T> Promise<T>.toMaybeObservable(): Maybe<T> = MaybeObservePromise(this)
 
-private class MaybePromise<T>(private val promise: Promise<T>) :
+private class MaybeObservePromise<T>(private val promise: Promise<T>) :
 	Maybe<T>(),
 	Disposable
 {

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/promises/extensions/ValuePromiseExtension.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/promises/extensions/ValuePromiseExtension.kt
@@ -83,7 +83,8 @@ private class CompletablePromise(completable: Completable) : Promise<Unit>(), Co
 	override fun onError(e: Throwable) = reject(e)
 }
 
-private class PromisedListenableFuture<Resolution>(listenableFuture: ListenableFuture<Resolution>, executor: Executor) : Promise<Resolution>() {
+private class PromisedListenableFuture<Resolution>(listenableFuture: ListenableFuture<Resolution>, executor: Executor) :
+	Promise<Resolution>() {
 	init {
 		respondToCancellation { listenableFuture.cancel(false) }
 		listenableFuture.addListener({
@@ -100,7 +101,7 @@ private class PromisedListenableFuture<Resolution>(listenableFuture: ListenableF
 
 private class PromiseJob(private val job: Job) : Promise<Unit>(), Runnable, CompletionHandler {
 	init {
-	    job.invokeOnCompletion(this)
+		job.invokeOnCompletion(this)
 		respondToCancellation(this)
 	}
 
@@ -115,9 +116,9 @@ private class PromiseJob(private val job: Job) : Promise<Unit>(), Runnable, Comp
 }
 
 @ExperimentalCoroutinesApi
-private class PromiseDeferred<T>(private val deferred: Deferred<T>): Promise<T>(), Runnable, CompletionHandler {
+private class PromiseDeferred<T>(private val deferred: Deferred<T>) : Promise<T>(), Runnable, CompletionHandler {
 	init {
-	    deferred.invokeOnCompletion(this)
+		deferred.invokeOnCompletion(this)
 		respondToCancellation(this)
 	}
 

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/browsing/library/access/PassThroughSpecificLibraryProvider.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/browsing/library/access/PassThroughSpecificLibraryProvider.kt
@@ -5,5 +5,5 @@ import com.lasthopesoftware.bluewater.shared.promises.extensions.toPromise
 import com.namehillsoftware.handoff.promises.Promise
 
 class PassThroughSpecificLibraryProvider(private val _library: Library) : ISpecificLibraryProvider {
-	override val library: Promise<Library?> = _library.toPromise()
+    override fun promiseLibrary(): Promise<Library?> = _library.toPromise()
 }

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndAPlaylistIsPreparing/WhenATrackIsSwitched.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndAPlaylistIsPreparing/WhenATrackIsSwitched.kt
@@ -9,6 +9,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -38,7 +39,8 @@ class WhenATrackIsSwitched {
 				) { 1 }, listOf(CompletingFileQueueProvider()),
 				NowPlayingRepository(
 					libraryProvider,
-					libraryStorage
+					libraryStorage,
+					FakeNowPlayingState(),
 				),
 				PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 			)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndAPlaylistIsPreparing/WhenATrackIsSwitched.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndAPlaylistIsPreparing/WhenATrackIsSwitched.kt
@@ -28,7 +28,7 @@ class WhenATrackIsSwitched {
 		library.setId(1)
 
 		val libraryProvider = mockk<ISpecificLibraryProvider>()
-		every { libraryProvider.library } returns (Promise(library))
+		every { libraryProvider.promiseLibrary() } returns (Promise(library))
 		val libraryStorage = mockk<ILibraryStorage>()
 		every { libraryStorage.saveLibrary(any()) } returns Promise(library)
 

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndAPlaylistIsPreparing/WhenATrackIsSwitchedTwice.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndAPlaylistIsPreparing/WhenATrackIsSwitchedTwice.kt
@@ -9,6 +9,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -29,7 +30,8 @@ class WhenATrackIsSwitchedTwice {
 			) { 1 }, listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f)))
 

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndPlaybackPlaysThroughCompletion/WhenObservingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/AndPlaybackPlaysThroughCompletion/WhenObservingPlayback.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayingFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import org.assertj.core.api.Assertions.assertThat
@@ -33,7 +34,8 @@ class WhenObservingPlayback {
 				) { 1 }, listOf(CompletingFileQueueProvider()),
 				NowPlayingRepository(
 					libraryProvider,
-					libraryStorage
+					libraryStorage,
+					FakeNowPlayingState(),
 				),
 				PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 			)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingToThePreviousTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingToThePreviousTrack.kt
@@ -16,6 +16,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.UrlKeyHolder
@@ -67,7 +68,8 @@ class WhenChangingToThePreviousTrack {
 				listOf(CompletingFileQueueProvider()),
 				NowPlayingRepository(
 					libraryProvider,
-					libraryStorage
+					libraryStorage,
+					FakeNowPlayingState(),
 				),
 				PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 			)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingToThePreviousTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingToThePreviousTrack.kt
@@ -50,8 +50,7 @@ class WhenChangingToThePreviousTrack {
 		libraryUnderTest.setNowPlayingId(4)
 
 		val libraryProvider = object : ISpecificLibraryProvider {
-			override val library: Promise<Library?>
-				get() = Promise(libraryUnderTest)
+            override fun promiseLibrary(): Promise<Library?> = Promise(libraryUnderTest)
 		}
 
 		val libraryStorage: ILibraryStorage = PassThroughLibraryStorage()

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingTracks.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingTracks.kt
@@ -12,6 +12,7 @@ import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedProgressedFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -53,7 +54,8 @@ class WhenChangingTracks {
 			) { 1 }, listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingTracks.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenChangingTracks.kt
@@ -45,7 +45,7 @@ class WhenChangingTracks {
 		)
 		library.setNowPlayingId(0)
 		val libraryProvider = mockk<ISpecificLibraryProvider>()
-		every { libraryProvider.library } returns Promise(library)
+		every { libraryProvider.promiseLibrary() } returns Promise(library)
 
 		val libraryStorage = PassThroughLibraryStorage()
 		val playbackEngine = PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingThePlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingThePlayingTrack.kt
@@ -41,7 +41,7 @@ class WhenMovingThePlayingTrack {
 
 		val fakePlaybackPreparerProvider = FakeDeferredPlayableFilePreparationSourceProvider()
 		val libraryProvider = mockk<ISpecificLibraryProvider>().apply {
-			every { library } returns Promise(storedLibrary)
+			every { promiseLibrary() } returns Promise(storedLibrary)
 		}
 
 		val playbackEngine = PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingThePlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingThePlayingTrack.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -48,7 +49,8 @@ class WhenMovingThePlayingTrack {
 			listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				PassThroughLibraryStorage()
+				PassThroughLibraryStorage(),
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromAfterToBeforePlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromAfterToBeforePlayingTrack.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -49,7 +50,8 @@ class WhenMovingTracksFromAfterToBeforePlayingTrack {
 			listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				PassThroughLibraryStorage()
+				PassThroughLibraryStorage(),
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromAfterToBeforePlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromAfterToBeforePlayingTrack.kt
@@ -42,7 +42,7 @@ class WhenMovingTracksFromAfterToBeforePlayingTrack {
 					)
 					.setNowPlayingId(0)
 			}
-			every { library } returns Promise(storedLibrary)
+			every { promiseLibrary() } returns Promise(storedLibrary)
 		}
 
 		val playbackEngine = PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToAfterPlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToAfterPlayingTrack.kt
@@ -42,7 +42,7 @@ class WhenMovingTracksFromBeforeToAfterPlayingTrack {
 					)
 					.setNowPlayingId(3)
 			}
-			every { library } returns Promise(storedLibrary)
+			every { promiseLibrary() } returns Promise(storedLibrary)
 		}
 
 		val playbackEngine = PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToAfterPlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToAfterPlayingTrack.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -49,7 +50,8 @@ class WhenMovingTracksFromBeforeToAfterPlayingTrack {
 			listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				PassThroughLibraryStorage()
+				PassThroughLibraryStorage(),
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToBeforePlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToBeforePlayingTrack.kt
@@ -42,7 +42,7 @@ class WhenMovingTracksFromBeforeToBeforePlayingTrack {
 					)
 					.setNowPlayingId(3)
 			}
-			every { library } returns Promise(storedLibrary)
+			every { promiseLibrary() } returns Promise(storedLibrary)
 		}
 
 		val playbackEngine = PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToBeforePlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToBeforePlayingTrack.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -49,7 +50,8 @@ class WhenMovingTracksFromBeforeToBeforePlayingTrack {
 			listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				PassThroughLibraryStorage()
+				PassThroughLibraryStorage(),
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToJustAfterPlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToJustAfterPlayingTrack.kt
@@ -42,7 +42,7 @@ class WhenMovingTracksFromBeforeToJustAfterPlayingTrack {
 					)
 					.setNowPlayingId(3)
 			}
-			every { library } returns Promise(storedLibrary)
+			every { promiseLibrary() } returns Promise(storedLibrary)
 		}
 
 		val playbackEngine = PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToJustAfterPlayingTrack.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenMovingTracksFromBeforeToJustAfterPlayingTrack.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -49,7 +50,8 @@ class WhenMovingTracksFromBeforeToJustAfterPlayingTrack {
 			listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				PassThroughLibraryStorage()
+				PassThroughLibraryStorage(),
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToComplete.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToComplete.kt
@@ -15,6 +15,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CyclicalFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.UrlKeyHolder
@@ -56,7 +57,8 @@ class WhenSettingEngineToComplete {
 		val repository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine =
 			PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToComplete.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToComplete.kt
@@ -46,7 +46,7 @@ class WhenSettingEngineToComplete {
 		library.setNowPlayingId(0)
 		library.setRepeating(true)
 		val libraryProvider = mockk<ISpecificLibraryProvider>()
-		every { libraryProvider.library } returns Promise(library)
+		every { libraryProvider.promiseLibrary() } returns Promise(library)
 
 		val libraryStorage = PassThroughLibraryStorage()
 		val filePropertiesContainerRepository = mockk<IFilePropertiesContainerRepository>()

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToRepeat.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToRepeat.kt
@@ -15,6 +15,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CyclicalFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.UrlKeyHolder
@@ -63,7 +64,8 @@ class WhenSettingEngineToRepeat {
 		val repository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToRepeat.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAHaltedPlaybackEngine/WhenSettingEngineToRepeat.kt
@@ -45,8 +45,7 @@ class WhenSettingEngineToRepeat {
 		)
 		library.setNowPlayingId(0)
 		val libraryProvider = object : ISpecificLibraryProvider {
-			override val library: Promise<Library?>
-				get() = library.toPromise()
+            override fun promiseLibrary(): Promise<Library?> = library.toPromise()
 		}
 
 		val libraryStorage = PassThroughLibraryStorage()

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/AndAnEmptyPlaylist/WhenRestoringEngineStateAndResumingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/AndAnEmptyPlaylist/WhenRestoringEngineStateAndResumingPlayback.kt
@@ -14,6 +14,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CyclicalFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.UrlKeyHolder
@@ -50,7 +51,8 @@ class WhenRestoringEngineStateAndResumingPlayback {
 		val repository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(fakePlaybackPreparerProvider) { 1 },

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/AndAnEmptyPlaylist/WhenRestoringEngineStateAndResumingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/AndAnEmptyPlaylist/WhenRestoringEngineStateAndResumingPlayback.kt
@@ -34,7 +34,7 @@ class WhenRestoringEngineStateAndResumingPlayback {
 		library.setNowPlayingId(586)
 
 		val libraryProvider = mockk<ISpecificLibraryProvider>()
-		every { libraryProvider.library } returns library.toPromise()
+		every { libraryProvider.promiseLibrary() } returns library.toPromise()
 
 		val libraryStorage = PassThroughLibraryStorage()
 

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/WhenRestoringEngineStateAndResumingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/WhenRestoringEngineStateAndResumingPlayback.kt
@@ -48,8 +48,7 @@ class WhenRestoringEngineStateAndResumingPlayback {
 		library.setNowPlayingProgress(893)
 		library.setNowPlayingId(3)
 		val libraryProvider = object : ISpecificLibraryProvider {
-			override val library: Promise<Library?>
-				get() = library.toPromise()
+            override fun promiseLibrary(): Promise<Library?> = library.toPromise()
 		}
 
 		val libraryStorage = PassThroughLibraryStorage()

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/WhenRestoringEngineStateAndResumingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenANewPlaybackEngine/WhenRestoringEngineStateAndResumingPlayback.kt
@@ -16,6 +16,7 @@ import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayingFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CyclicalFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.UrlKeyHolder
@@ -66,7 +67,8 @@ class WhenRestoringEngineStateAndResumingPlayback {
 		val repository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(fakePlaybackPreparerProvider) { 1 },

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/AndAPreparationErrorOccurs/WhenObservingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/AndAPreparationErrorOccurs/WhenObservingPlayback.kt
@@ -46,7 +46,7 @@ class WhenObservingPlayback {
 		val libraryProvider = mockk<ISpecificLibraryProvider>().also {
 			val library = Library()
 			library.setId(1)
-			every { it.library } returns Promise(library)
+			every { it.promiseLibrary() } returns Promise(library)
 		}
 
 		val libraryStorage: ILibraryStorage = PassThroughLibraryStorage()

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/AndAPreparationErrorOccurs/WhenObservingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/AndAPreparationErrorOccurs/WhenObservingPlayback.kt
@@ -15,6 +15,7 @@ import com.lasthopesoftware.bluewater.client.playback.file.fakes.ResolvablePlayb
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PlayableFilePreparationSource
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PreparedPlayableFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
@@ -49,7 +50,11 @@ class WhenObservingPlayback {
 		}
 
 		val libraryStorage: ILibraryStorage = PassThroughLibraryStorage()
-		val nowPlayingRepository = NowPlayingRepository(libraryProvider, libraryStorage)
+		val nowPlayingRepository = NowPlayingRepository(
+			libraryProvider,
+			libraryStorage,
+			FakeNowPlayingState(),
+		)
 
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/AndAnErrorOccurs/WhenObservingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/AndAnErrorOccurs/WhenObservingPlayback.kt
@@ -11,6 +11,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PlayableFilePreparationSource
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PreparedPlayableFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.namehillsoftware.handoff.Messenger
@@ -42,7 +43,8 @@ class WhenObservingPlayback {
 			), listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenChangingTracks.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenChangingTracks.kt
@@ -11,6 +11,7 @@ import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayingFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -35,7 +36,8 @@ class WhenChangingTracks {
 				) { 1 }, listOf(CompletingFileQueueProvider()),
 				NowPlayingRepository(
 					libraryProvider,
-					libraryStorage
+					libraryStorage,
+					FakeNowPlayingState(),
 				),
 				PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 			)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenNotObservingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenNotObservingPlayback.kt
@@ -26,7 +26,7 @@ class WhenNotObservingPlayback {
 		val fakePlaybackPreparerProvider = FakeDeferredPlayableFilePreparationSourceProvider()
 
 		val libraryProvider = mockk<ISpecificLibraryProvider>()
-		every { libraryProvider.library } returns Promise(library)
+		every { libraryProvider.promiseLibrary() } returns Promise(library)
 
 		val libraryStorage = mockk<ILibraryStorage>()
 		every { libraryStorage.saveLibrary(any()) } returns	Promise(library)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenNotObservingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenNotObservingPlayback.kt
@@ -9,6 +9,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.PlaylistP
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlaybackQueueResourceManagement
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.namehillsoftware.handoff.promises.Promise
@@ -36,7 +37,8 @@ class WhenNotObservingPlayback {
 			) { 1 }, listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenObservingPlayback.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenObservingPlayback.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayingFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import org.assertj.core.api.Assertions.assertThat
@@ -31,7 +32,8 @@ class WhenObservingPlayback {
 			) { 1 }, listOf(CompletingFileQueueProvider()),
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			),
 			PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 		)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackCompletes.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackCompletes.kt
@@ -11,6 +11,7 @@ import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayingFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
@@ -31,7 +32,8 @@ class WhenPlaybackCompletes {
 		val nowPlayingRepository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsInterrupted.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsInterrupted.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.fakes.ResolvablePlaybackHandler
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
@@ -30,7 +31,8 @@ class WhenPlaybackIsInterrupted {
 		val nowPlayingRepository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsPaused.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsPaused.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.fakes.ResolvablePlaybackHandler
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
@@ -30,7 +31,8 @@ class WhenPlaybackIsPaused {
 		val nowPlayingRepository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsPausedAndPositionIsChangedAndRestarted.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsPausedAndPositionIsChangedAndRestarted.kt
@@ -11,6 +11,7 @@ import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayingFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
@@ -31,7 +32,8 @@ class WhenPlaybackIsPausedAndPositionIsChangedAndRestarted {
 		val nowPlayingRepository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine =
 			PlaybackEngine(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsPausedAndRestarted.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenPlaybackIsPausedAndRestarted.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.fakes.ResolvablePlaybackHandler
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
@@ -29,7 +30,8 @@ class WhenPlaybackIsPausedAndRestarted {
 		val nowPlayingRepository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				FakeNowPlayingState(),
 			)
 		val playbackEngine = PlaybackEngine(
 			PreparedPlaybackQueueResourceManagement(

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingFilesBeforeTheCurrentlyPlayingFile.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingFilesBeforeTheCurrentlyPlayingFile.kt
@@ -11,6 +11,7 @@ import com.lasthopesoftware.bluewater.client.playback.engine.preparation.Prepare
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedProgressedFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
@@ -48,10 +49,12 @@ class WhenRemovingFilesBeforeTheCurrentlyPlayingFile {
 
 		val libraryStorage = PassThroughLibraryStorage()
 
+		val nowPlayingState = FakeNowPlayingState()
 		val repository =
 			NowPlayingRepository(
 				libraryProvider,
-				libraryStorage
+				libraryStorage,
+				nowPlayingState,
 			)
 		val playbackEngine =
 			PlaybackEngine(
@@ -66,7 +69,8 @@ class WhenRemovingFilesBeforeTheCurrentlyPlayingFile {
 				}),
 				NowPlayingRepository(
 					libraryProvider,
-					libraryStorage
+					libraryStorage,
+					nowPlayingState,
 				),
 				PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 			)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingFilesBeforeTheCurrentlyPlayingFile.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingFilesBeforeTheCurrentlyPlayingFile.kt
@@ -45,7 +45,7 @@ class WhenRemovingFilesBeforeTheCurrentlyPlayingFile {
 		library.setNowPlayingId(2)
 
 		val libraryProvider = mockk<ISpecificLibraryProvider>()
-		every { libraryProvider.library } returns Promise(library)
+		every { libraryProvider.promiseLibrary() } returns Promise(library)
 
 		val libraryStorage = PassThroughLibraryStorage()
 

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingTheCurrentlyPlayingFile.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingTheCurrentlyPlayingFile.kt
@@ -49,7 +49,7 @@ class WhenRemovingTheCurrentlyPlayingFile {
 		)
 		library.setNowPlayingId(5)
 		val libraryProvider = mockk<ISpecificLibraryProvider>()
-		every { libraryProvider.library } returns Promise(library)
+		every { libraryProvider.promiseLibrary() } returns Promise(library)
 
 		val libraryStorage = PassThroughLibraryStorage()
 		val filePropertiesContainerRepository = mockk<IFilePropertiesContainerRepository>()

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingTheCurrentlyPlayingFile.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/GivenAPlayingPlaybackEngine/WhenRemovingTheCurrentlyPlayingFile.kt
@@ -16,6 +16,7 @@ import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayingFile
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedProgressedFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.FakeDeferredPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.queues.CompletingFileQueueProvider
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
 import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
 import com.lasthopesoftware.bluewater.client.playback.volume.PlaylistVolumeManager
 import com.lasthopesoftware.bluewater.shared.UrlKeyHolder
@@ -64,7 +65,8 @@ class WhenRemovingTheCurrentlyPlayingFile {
 				listOf(CompletingFileQueueProvider()),
 				NowPlayingRepository(
 					libraryProvider,
-					libraryStorage
+					libraryStorage,
+					FakeNowPlayingState(),
 				),
 				PlaylistPlaybackBootstrapper(PlaylistVolumeManager(1.0f))
 			)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/FakeNowPlayingState.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/FakeNowPlayingState.kt
@@ -1,0 +1,13 @@
+package com.lasthopesoftware.bluewater.client.playback.nowplaying.storage
+
+import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
+
+class FakeNowPlayingState : HoldNowPlayingState {
+	private val nowPlayingCache = HashMap<LibraryId, NowPlaying>()
+
+	override fun set(libraryId: LibraryId, nowPlaying: NowPlaying) {
+		nowPlayingCache[libraryId] = nowPlaying
+	}
+
+	override fun get(libraryId: LibraryId): NowPlaying? = nowPlayingCache[libraryId]
+}

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/GivenALibrary/AndItHasAlreadyBeenRetrieved/WhenGettingNowPlayingState.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/storage/GivenALibrary/AndItHasAlreadyBeenRetrieved/WhenGettingNowPlayingState.kt
@@ -1,0 +1,71 @@
+package com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.GivenALibrary.AndItHasAlreadyBeenRetrieved
+
+import com.lasthopesoftware.bluewater.client.browsing.files.ServiceFile
+import com.lasthopesoftware.bluewater.client.browsing.library.repository.Library
+import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
+import com.lasthopesoftware.bluewater.client.playback.file.PositionedFile
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.FakeNowPlayingState
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlaying
+import com.lasthopesoftware.bluewater.client.playback.nowplaying.storage.NowPlayingRepository
+import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
+import com.lasthopesoftware.bluewater.shared.promises.extensions.toPromise
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class WhenGettingNowPlayingState {
+
+	private val mut by lazy {
+		NowPlayingRepository(
+			mockk {
+				every { promiseLibrary() } returns Library(
+					_id = 521,
+					_nowPlayingProgress = 435,
+					_nowPlayingId = 2,
+					_savedTracksString = "2;-1;130;32;22;",
+					_isRepeating = false
+				).toPromise()
+			},
+			mockk(),
+			FakeNowPlayingState().apply {
+				set(
+					LibraryId(521),
+					NowPlaying(
+						LibraryId(521),
+						listOf(ServiceFile(780), ServiceFile(979), ServiceFile(655)),
+						1,
+						672,
+						true
+					),
+				)
+			}
+		)
+	}
+
+	private var nowPlaying: NowPlaying? = null
+
+	@BeforeAll
+	fun act() {
+		nowPlaying = mut.promiseNowPlaying().toExpiringFuture().get()
+	}
+
+	@Test
+	fun `then the playing file is correct`() {
+		assertThat(nowPlaying?.playingFile).isEqualTo(PositionedFile(1, ServiceFile(979)))
+	}
+
+	@Test
+	fun `then now playing is correct`() {
+		assertThat(nowPlaying).isEqualTo(
+			NowPlaying(
+				LibraryId(521),
+				listOf(ServiceFile(780), ServiceFile(979), ServiceFile(655)),
+				1,
+				672,
+				true
+			)
+		)
+	}
+}


### PR DESCRIPTION
When starting a new playlist, the playlist will be out of date on the initial launch of the now playing activity. This was due to not using the cached value, when it was expected that the cache would be used. 