### PR TITLE
[Chore] Improve Playlist Completed Behavior

### DIFF
--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/files/properties/playstats/UpdatePlayStatsOnPlaybackCompletedReceiver.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/files/properties/playstats/UpdatePlayStatsOnPlaybackCompletedReceiver.kt
@@ -41,5 +41,7 @@ class UpdatePlayStatsOnPlaybackCompletedReceiver(
 		)
 	}
 
-	override fun promiseClose(): Promise<Unit> = promiseTracker.promiseClose()
+	override fun promiseClose(): Promise<Unit> = promiseUpdatesFinish()
+
+	fun promiseUpdatesFinish(): Promise<Unit> = promiseTracker.promiseAllConcluded()
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/PlaybackNotificationRouter.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/PlaybackNotificationRouter.kt
@@ -10,26 +10,22 @@ abstract class PlaybackNotificationRouter(
 	registerApplicationMessages: RegisterForApplicationMessages,
 ) : AutoCloseable
 {
-	private val autoCloseableManager = AutoCloseableManager()
-
-	init {
-		with(autoCloseableManager) {
-			manage(registerApplicationMessages.registerReceiver<LibraryPlaybackMessage.TrackChanged> {
-				notifyPlayingFileUpdated()
-			})
-			manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackStarted> {
-				notifyPlaying()
-			})
-			manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackPaused> {
-				notifyPaused()
-			})
-			manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackInterrupted> {
-				notifyInterrupted()
-			})
-			manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackStopped> {
-				notifyStopped()
-			})
-		}
+	private val autoCloseableManager = AutoCloseableManager().apply {
+		manage(registerApplicationMessages.registerReceiver<LibraryPlaybackMessage.TrackChanged> {
+			notifyPlayingFileUpdated()
+		})
+		manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackStarted> {
+			notifyPlaying()
+		})
+		manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackPaused> {
+			notifyPaused()
+		})
+		manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackInterrupted> {
+			notifyInterrupted()
+		})
+		manage(registerApplicationMessages.registerReceiver<PlaybackMessage.PlaybackStopped> {
+			notifyStopped()
+		})
 	}
 
 	protected abstract fun notifyPlaying()

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/notification/PlaybackNotificationBroadcaster.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/notification/PlaybackNotificationBroadcaster.kt
@@ -87,12 +87,14 @@ class PlaybackNotificationBroadcaster(
 		}
 
 		nowPlayingNotificationContentBuilder
-			.promiseNowPlayingNotification(libraryId, currentServiceFile, false.also { isPlaying = false })
+			.promiseNowPlayingNotification(libraryId, currentServiceFile, false)
 			.then {
 				it?.apply {
 					notificationsController.notifyBackground(build(), notificationId)
 				}
 			}
+
+		isPlaying = false
 	}
 
 	override fun notifyInterrupted() {
@@ -104,21 +106,17 @@ class PlaybackNotificationBroadcaster(
 		}
 
 		nowPlayingNotificationContentBuilder
-			.promiseNowPlayingNotification(libraryId, currentServiceFile, false.also { isPlaying = it })
+			.promiseNowPlayingNotification(libraryId, currentServiceFile, false)
 			.then {
 				it?.apply {
 					notificationsController.notifyForeground(build(), notificationId)
 				}
 			}
+
+		isPlaying = false
 	}
 
-	override fun notifyStopped() {
-		synchronized(notificationSync) {
-			isPlaying = false
-			isNotificationStarted = false
-			notificationsController.removeNotification(notificationId)
-		}
-	}
+	override fun notifyStopped() = notifyPaused()
 
 	override fun notifyPlayingFileUpdated() {
 		nowPlayingState.promiseActiveNowPlaying().then { np ->

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/remote/MediaSessionBroadcaster.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/remote/MediaSessionBroadcaster.kt
@@ -59,6 +59,7 @@ class MediaSessionBroadcaster(
 
 	override fun close() {
 		trackPositionUpdatesSubscription.close()
+		clearClientBitmap()
 		super.close()
 	}
 
@@ -94,7 +95,6 @@ class MediaSessionBroadcaster(
 			playbackSpeed
 		)
 		mediaSession.setPlaybackState(builder.build())
-		clearClientBitmap()
 	}
 
 	override fun notifyInterrupted() {

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/promises/PromiseTracker.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/promises/PromiseTracker.kt
@@ -1,11 +1,10 @@
 package com.lasthopesoftware.bluewater.shared.promises
 
 import com.lasthopesoftware.bluewater.shared.promises.extensions.guaranteedUnitResponse
-import com.lasthopesoftware.resources.closables.PromisingCloseable
 import com.namehillsoftware.handoff.promises.Promise
 import java.util.concurrent.ConcurrentHashMap
 
-class PromiseTracker : PromisingCloseable {
+class PromiseTracker {
 	private val activePromises = ConcurrentHashMap<Promise<*>, Promise<Unit>>()
 
 	fun <T> track(promise: Promise<T>) {
@@ -16,7 +15,7 @@ class PromiseTracker : PromisingCloseable {
 		}
 	}
 
-	override fun promiseClose(): Promise<Unit> = Promise
+	fun promiseAllConcluded(): Promise<Unit> = Promise
 		.whenAll(activePromises.values)
 		.guaranteedUnitResponse()
 		.must { activePromises.clear() }

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/notification/GivenAStandardNotificationManager/AndPlaybackHasStarted/AndTheFileHasChanged/AfterPlaybackHasStopped/WhenTheFileChanges.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/notification/GivenAStandardNotificationManager/AndPlaybackHasStarted/AndTheFileHasChanged/AfterPlaybackHasStopped/WhenTheFileChanges.kt
@@ -96,11 +96,11 @@ class WhenTheFileChanges : AndroidContext() {
 
     @Test
     fun `then the service does not continue in the background`() {
-		verify { service.stopForeground(Service.STOP_FOREGROUND_REMOVE) }
+		verify { service.stopForeground(Service.STOP_FOREGROUND_DETACH) }
     }
 
     @Test
-    fun `then the notification is not set to the second notification`() {
-		verify(exactly = 0) { notificationManager.notify(43, secondNotification) }
+    fun `then the notification is set to the second notification`() {
+		verify { notificationManager.notify(43, secondNotification) }
     }
 }

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/notification/GivenAStandardNotificationManager/AndPlaybackHasStarted/AndTheFileHasChanged/AndPlaybackIsStopped/WhenTheFileChanges.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/notification/GivenAStandardNotificationManager/AndPlaybackHasStarted/AndTheFileHasChanged/AndPlaybackIsStopped/WhenTheFileChanges.kt
@@ -91,11 +91,11 @@ class WhenTheFileChanges : AndroidContext() {
 
 	@Test
 	fun `then the service does not continue in the background`() {
-		verify { service.stopForeground(Service.STOP_FOREGROUND_REMOVE) }
+		verify { service.stopForeground(Service.STOP_FOREGROUND_DETACH) }
 	}
 
 	@Test
-	fun `then the notification is not set to the second notification`() {
-		verify(exactly = 0) { notificationManager.notify(43, secondNotification) }
+	fun `then the notification is set to the second notification`() {
+		verify { notificationManager.notify(43, secondNotification) }
 	}
 }

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/remote/GivenAStandardNotificationManager/AndPlaybackHasStarted/AndTheFileHasChanged/AndPlaybackIsStopped/WhenTheFileChanges.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/nowplaying/broadcasters/remote/GivenAStandardNotificationManager/AndPlaybackHasStarted/AndTheFileHasChanged/AndPlaybackIsStopped/WhenTheFileChanges.kt
@@ -50,13 +50,13 @@ class WhenTheFileChanges : AndroidContext() {
 			},
 			mediaSessionCompat,
 			messageBus,
-		)
-
-		with (messageBus) {
-			sendMessage(PlaybackMessage.PlaybackStarted)
-			sendMessage(LibraryPlaybackMessage.TrackChanged(LibraryId(libraryId), nowPlaying.playingFile!!))
-			sendMessage(PlaybackMessage.PlaybackStopped)
-			sendMessage(LibraryPlaybackMessage.TrackChanged(LibraryId(libraryId), nowPlaying.playingFile!!))
+		).use {
+			with(messageBus) {
+				sendMessage(PlaybackMessage.PlaybackStarted)
+				sendMessage(LibraryPlaybackMessage.TrackChanged(LibraryId(libraryId), nowPlaying.playingFile!!))
+				sendMessage(PlaybackMessage.PlaybackStopped)
+				sendMessage(LibraryPlaybackMessage.TrackChanged(LibraryId(libraryId), nowPlaying.playingFile!!))
+			}
 		}
 	}
 


### PR DESCRIPTION
- Do not turn off notifications (treat it as paused).
- Only wait for updates to finish before initiating shutdown when playlist completes.
- Stop service immediately in `haltService`.