### PR TITLE
[Bugfix] Load Control Thread Coupling

### DIFF
--- a/projectBlueWater/build.gradle
+++ b/projectBlueWater/build.gradle
@@ -170,11 +170,11 @@ def getGeneratedVersionCode() {
 
 dependencies {
 	def compose_version = '1.6.8'
-	def media3_version = '1.4.0'
+	def media3_version = '1.4.1'
 	def lifecycle_version = '2.8.4'
 	def junit5_version = '5.11.0'
 
-	coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
+	coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.1'
 
 	implementation 'androidx.core:core-ktx:1.13.1'
 	implementation 'androidx.annotation:annotation:1.8.2'

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/ExoPlayerProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/ExoPlayerProvider.kt
@@ -2,11 +2,14 @@ package com.lasthopesoftware.bluewater.client.playback.exoplayer
 
 import android.content.Context
 import android.os.Handler
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.LoadControl
 import androidx.media3.exoplayer.RenderersFactory
 
-class ExoPlayerProvider(
+@OptIn(UnstableApi::class) class ExoPlayerProvider
+	(
 	private val context: Context,
 	private val renderersFactory: RenderersFactory,
 	private val loadControl: LoadControl,
@@ -14,7 +17,7 @@ class ExoPlayerProvider(
 ) :
 	ProvideExoPlayers
 {
-	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+	@OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getExoPlayer(): PromisingExoPlayer {
 		val exoPlayerBuilder = ExoPlayer.Builder(context, renderersFactory)
 			.setLoadControl(loadControl)

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/ExoPlayerProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/ExoPlayerProvider.kt
@@ -22,6 +22,7 @@ import androidx.media3.exoplayer.RenderersFactory
 		val exoPlayerBuilder = ExoPlayer.Builder(context, renderersFactory)
 			.setLoadControl(loadControl)
 			.setLooper(playbackHandler.looper)
+			.setPlaybackLooper(playbackHandler.looper)
 
 		return HandlerDispatchingExoPlayer(exoPlayerBuilder.build(), playbackHandler)
 	}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/ExoPlayerProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/ExoPlayerProvider.kt
@@ -8,11 +8,11 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.LoadControl
 import androidx.media3.exoplayer.RenderersFactory
 
-@OptIn(UnstableApi::class) class ExoPlayerProvider
-	(
+@OptIn(UnstableApi::class) class ExoPlayerProvider(
 	private val context: Context,
 	private val renderersFactory: RenderersFactory,
 	private val loadControl: LoadControl,
+	private val playerInteractionsHandler: Handler,
 	private val playbackHandler: Handler,
 ) :
 	ProvideExoPlayers
@@ -21,9 +21,9 @@ import androidx.media3.exoplayer.RenderersFactory
 	override fun getExoPlayer(): PromisingExoPlayer {
 		val exoPlayerBuilder = ExoPlayer.Builder(context, renderersFactory)
 			.setLoadControl(loadControl)
-			.setLooper(playbackHandler.looper)
+			.setLooper(playerInteractionsHandler.looper)
 			.setPlaybackLooper(playbackHandler.looper)
 
-		return HandlerDispatchingExoPlayer(exoPlayerBuilder.build(), playbackHandler)
+		return HandlerDispatchingExoPlayer(exoPlayerBuilder.build(), playerInteractionsHandler)
 	}
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/HandlerDispatchingExoPlayer.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/exoplayer/HandlerDispatchingExoPlayer.kt
@@ -14,628 +14,457 @@ import androidx.media3.exoplayer.SeekParameters
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ShuffleOrder
 import androidx.media3.exoplayer.trackselection.TrackSelector
-import com.lasthopesoftware.promises.extensions.LoopedInPromise
+import com.lasthopesoftware.promises.extensions.LoopedInPromise.Companion.loopIn
 import com.namehillsoftware.handoff.promises.Promise
-import com.namehillsoftware.handoff.promises.queued.MessageWriter
 
-class HandlerDispatchingExoPlayer(private val innerPlayer: ExoPlayer, private val handler: Handler) : PromisingExoPlayer {
+class HandlerDispatchingExoPlayer(private val innerPlayer: ExoPlayer, private val handler: Handler) :
+	PromisingExoPlayer {
 
-	override fun getApplicationLooper(): Promise<Looper> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.applicationLooper },
-			handler)
+	override fun getApplicationLooper(): Promise<Looper> = handler.loopIn { innerPlayer.applicationLooper }
 
 	override fun addListener(listener: Player.Listener): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addListener(listener)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addListener(listener)
+			this
+		}
 
 	override fun removeListener(listener: Player.Listener): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.removeListener(listener)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.removeListener(listener)
+			this
+		}
 
 	override fun setMediaItems(mediaItems: MutableList<MediaItem>): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaItems(mediaItems)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaItems(mediaItems)
+			this
+		}
 
-	override fun setMediaItems(mediaItems: MutableList<MediaItem>, resetPosition: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaItems(mediaItems, resetPosition)
-				this
-			},
-			handler)
+	override fun setMediaItems(
+		mediaItems: MutableList<MediaItem>,
+		resetPosition: Boolean): Promise<PromisingExoPlayer> =
+		handler.loopIn {
+			innerPlayer.setMediaItems(mediaItems, resetPosition)
+			this
+		}
 
-	override fun setMediaItems(mediaItems: MutableList<MediaItem>, startWindowIndex: Int, startPositionMs: Long): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaItems(mediaItems, startWindowIndex, startPositionMs)
-				this
-			},
-			handler)
+	override fun setMediaItems(
+		mediaItems: MutableList<MediaItem>,
+		startWindowIndex: Int,
+		startPositionMs: Long
+	): Promise<PromisingExoPlayer> =
+		handler.loopIn {
+			innerPlayer.setMediaItems(mediaItems, startWindowIndex, startPositionMs)
+			this
+		}
 
 	override fun setMediaItem(mediaItem: MediaItem): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaItem(mediaItem)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaItem(mediaItem)
+			this
+		}
 
 	override fun setMediaItem(mediaItem: MediaItem, startPositionMs: Long): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaItem(mediaItem, startPositionMs)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaItem(mediaItem, startPositionMs)
+			this
+		}
 
 	override fun setMediaItem(mediaItem: MediaItem, resetPosition: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaItem(mediaItem, resetPosition)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaItem(mediaItem, resetPosition)
+			this
+		}
 
 	override fun setVolume(volume: Float): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.volume = volume
-				this
-			},
-			handler
-		)
+		handler.loopIn {
+			innerPlayer.volume = volume
+			this
+		}
 
 	override fun addMediaItem(mediaItem: MediaItem): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaItem(mediaItem)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaItem(mediaItem)
+			this
+		}
 
 	override fun addMediaItem(index: Int, mediaItem: MediaItem): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaItem(index, mediaItem)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaItem(index, mediaItem)
+			this
+		}
 
 	override fun addMediaItems(mediaItems: MutableList<MediaItem>): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaItems(mediaItems)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaItems(mediaItems)
+			this
+		}
 
 	override fun addMediaItems(index: Int, mediaItems: MutableList<MediaItem>): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaItems(index, mediaItems)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaItems(index, mediaItems)
+			this
+		}
 
 	override fun moveMediaItem(currentIndex: Int, newIndex: Int): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.moveMediaItem(currentIndex, newIndex)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.moveMediaItem(currentIndex, newIndex)
+			this
+		}
 
 	override fun moveMediaItems(fromIndex: Int, toIndex: Int, newIndex: Int): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.moveMediaItems(fromIndex, toIndex, newIndex)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.moveMediaItems(fromIndex, toIndex, newIndex)
+			this
+		}
 
 	override fun removeMediaItem(index: Int): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.removeMediaItem(index)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.removeMediaItem(index)
+			this
+		}
 
 	override fun removeMediaItems(fromIndex: Int, toIndex: Int): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.removeMediaItems(fromIndex, toIndex)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.removeMediaItems(fromIndex, toIndex)
+			this
+		}
 
 	override fun clearMediaItems(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.clearMediaItems()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.clearMediaItems()
+			this
+		}
 
 	override fun prepare(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.prepare()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.prepare()
+			this
+		}
 
 	override fun getPlaybackState(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.playbackState },
-			handler)
+		handler.loopIn { innerPlayer.playbackState }
 
 	override fun getPlaybackSuppressionReason(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.playbackSuppressionReason },
-			handler)
+		handler.loopIn { innerPlayer.playbackSuppressionReason }
 
 	override fun isPlaying(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.isPlaying },
-			handler)
+		handler.loopIn { innerPlayer.isPlaying }
 
 	override fun getPlayerError(): Promise<ExoPlaybackException?> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.playerError },
-			handler)
+		handler.loopIn { innerPlayer.playerError }
 
 	override fun play(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.play()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.play()
+			this
+		}
 
 	override fun pause(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.pause()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.pause()
+			this
+		}
 
 	override fun setPlayWhenReady(playWhenReady: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.playWhenReady = playWhenReady
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.playWhenReady = playWhenReady
+			this
+		}
 
 	override fun getPlayWhenReady(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.playWhenReady },
-			handler)
+		handler.loopIn { innerPlayer.playWhenReady }
 
 	override fun setRepeatMode(repeatMode: Int): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.repeatMode = repeatMode
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.repeatMode = repeatMode
+			this
+		}
 
 	override fun getRepeatMode(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.repeatMode },
-			handler)
+		handler.loopIn { innerPlayer.repeatMode }
 
 	override fun setShuffleModeEnabled(shuffleModeEnabled: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.shuffleModeEnabled = shuffleModeEnabled
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.shuffleModeEnabled = shuffleModeEnabled
+			this
+		}
 
 	override fun getShuffleModeEnabled(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.shuffleModeEnabled },
-			handler)
+		handler.loopIn { innerPlayer.shuffleModeEnabled }
 
 	override fun isLoading(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.isLoading },
-			handler)
+		handler.loopIn { innerPlayer.isLoading }
 
 	override fun seekToDefaultPosition(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.seekToDefaultPosition()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.seekToDefaultPosition()
+			this
+		}
 
 	override fun seekToDefaultPosition(windowIndex: Int): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.seekToDefaultPosition(windowIndex)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.seekToDefaultPosition(windowIndex)
+			this
+		}
 
 	override fun seekTo(positionMs: Long): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.seekTo(positionMs)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.seekTo(positionMs)
+			this
+		}
 
 	override fun seekTo(windowIndex: Int, positionMs: Long): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.seekTo(windowIndex, positionMs)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.seekTo(windowIndex, positionMs)
+			this
+		}
 
 	override fun hasPreviousMediaItem(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.hasPreviousMediaItem() },
-			handler)
+		handler.loopIn { innerPlayer.hasPreviousMediaItem() }
 
 	override fun seekToPreviousMediaItem(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.seekToPreviousMediaItem()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.seekToPreviousMediaItem()
+			this
+		}
 
 	override fun hasNextMediaItem(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.hasNextMediaItem() },
-			handler)
+		handler.loopIn { innerPlayer.hasNextMediaItem() }
 
 	override fun seekToNextMediaItem(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.seekToNextMediaItem()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.seekToNextMediaItem()
+			this
+		}
 
 	override fun setPlaybackParameters(playbackParameters: PlaybackParameters): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.playbackParameters = playbackParameters
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.playbackParameters = playbackParameters
+			this
+		}
 
 	override fun getPlaybackParameters(): Promise<PlaybackParameters> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.playbackParameters },
-			handler)
+		handler.loopIn { innerPlayer.playbackParameters }
 
 	override fun stop(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.stop()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.stop()
+			this
+		}
 
 	override fun release(): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.release()
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.release()
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getRendererCount(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter<Int> { innerPlayer.rendererCount },
-			handler)
+		handler.loopIn { innerPlayer.rendererCount }
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getRendererType(index: Int): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.getRendererType(index) },
-			handler)
+		handler.loopIn { innerPlayer.getRendererType(index) }
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getTrackSelector(): Promise<TrackSelector?> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.trackSelector },
-			handler)
+		handler.loopIn { innerPlayer.trackSelector }
 
 	override fun getCurrentTracks(): Promise<Tracks?> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentTracks },
-			handler)
+		handler.loopIn { innerPlayer.currentTracks }
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getCurrentManifest(): Promise<Any?> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentManifest },
-			handler)
+		handler.loopIn { innerPlayer.currentManifest }
 
 	override fun getCurrentTimeline(): Promise<Timeline> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentTimeline },
-			handler)
+		handler.loopIn { innerPlayer.currentTimeline }
 
 	override fun getCurrentPeriodIndex(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentPeriodIndex },
-			handler)
+		handler.loopIn { innerPlayer.currentPeriodIndex }
 
 	override fun getCurrentMediaItemIndex(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentMediaItemIndex },
-			handler)
+		handler.loopIn { innerPlayer.currentMediaItemIndex }
 
 	override fun getNextMediaItemIndex(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.nextMediaItemIndex },
-			handler)
+		handler.loopIn { innerPlayer.nextMediaItemIndex }
 
 	override fun getPreviousMediaItemIndex(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.previousMediaItemIndex },
-			handler)
+		handler.loopIn { innerPlayer.previousMediaItemIndex }
 
 	override fun getCurrentMediaItem(): Promise<MediaItem?> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentMediaItem },
-			handler)
+		handler.loopIn { innerPlayer.currentMediaItem }
 
 	override fun getMediaItemCount(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.mediaItemCount },
-			handler)
+		handler.loopIn { innerPlayer.mediaItemCount }
 
 	override fun getMediaItemAt(index: Int): Promise<MediaItem> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.getMediaItemAt(index) },
-			handler)
+		handler.loopIn { innerPlayer.getMediaItemAt(index) }
 
 	override fun getDuration(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.duration },
-			handler)
+		handler.loopIn { innerPlayer.duration }
 
 	override fun getCurrentPosition(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentPosition },
-			handler)
+		handler.loopIn { innerPlayer.currentPosition }
 
 	override fun getBufferedPosition(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.bufferedPosition },
-			handler)
+		handler.loopIn { innerPlayer.bufferedPosition }
 
 	override fun getBufferedPercentage(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.bufferedPercentage },
-			handler)
+		handler.loopIn { innerPlayer.bufferedPercentage }
 
 	override fun getTotalBufferedDuration(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.totalBufferedDuration },
-			handler)
+		handler.loopIn { innerPlayer.totalBufferedDuration }
 
 	override fun isCurrentMediaItemDynamic(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.isCurrentMediaItemDynamic },
-			handler)
+		handler.loopIn { innerPlayer.isCurrentMediaItemDynamic }
 
 	override fun isCurrentMediaItemLive(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.isCurrentMediaItemLive },
-			handler)
+		handler.loopIn { innerPlayer.isCurrentMediaItemLive }
 
 	override fun getCurrentLiveOffset(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentLiveOffset },
-			handler)
+		handler.loopIn { innerPlayer.currentLiveOffset }
 
 	override fun isCurrentMediaItemSeekable(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.isCurrentMediaItemSeekable },
-			handler)
+		handler.loopIn { innerPlayer.isCurrentMediaItemSeekable }
 
 	override fun isPlayingAd(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.isPlayingAd },
-			handler)
+		handler.loopIn { innerPlayer.isPlayingAd }
 
 	override fun getCurrentAdGroupIndex(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentAdGroupIndex },
-			handler)
+		handler.loopIn { innerPlayer.currentAdGroupIndex }
 
 	override fun getCurrentAdIndexInAdGroup(): Promise<Int> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.currentAdIndexInAdGroup },
-			handler)
+		handler.loopIn { innerPlayer.currentAdIndexInAdGroup }
 
 	override fun getContentDuration(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.contentDuration },
-			handler)
+		handler.loopIn { innerPlayer.contentDuration }
 
 	override fun getContentPosition(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.contentPosition },
-			handler)
+		handler.loopIn { innerPlayer.contentPosition }
 
 	override fun getContentBufferedPosition(): Promise<Long> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.contentBufferedPosition },
-			handler)
+		handler.loopIn { innerPlayer.contentBufferedPosition }
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getPlaybackLooper(): Promise<Looper> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.playbackLooper },
-			handler)
+		handler.loopIn { innerPlayer.playbackLooper }
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setMediaSources(mediaSources: MutableList<MediaSource>): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaSources(mediaSources)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaSources(mediaSources)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-	override fun setMediaSources(mediaSources: MutableList<MediaSource>, resetPosition: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaSources(mediaSources, resetPosition)
-				this
-			},
-			handler)
+	override fun setMediaSources(
+		mediaSources: MutableList<MediaSource>,
+		resetPosition: Boolean
+	): Promise<PromisingExoPlayer> =
+		handler.loopIn {
+			innerPlayer.setMediaSources(mediaSources, resetPosition)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-	override fun setMediaSources(mediaSources: MutableList<MediaSource>, startWindowIndex: Int, startPositionMs: Long): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaSources(mediaSources, startWindowIndex, startPositionMs)
-				this
-			},
-			handler)
+	override fun setMediaSources(
+		mediaSources: MutableList<MediaSource>,
+		startWindowIndex: Int,
+		startPositionMs: Long
+	): Promise<PromisingExoPlayer> =
+		handler.loopIn {
+			innerPlayer.setMediaSources(mediaSources, startWindowIndex, startPositionMs)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setMediaSource(mediaSource: MediaSource): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaSource(mediaSource)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaSource(mediaSource)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setMediaSource(mediaSource: MediaSource, startPositionMs: Long): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaSource(mediaSource, startPositionMs)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaSource(mediaSource, startPositionMs)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setMediaSource(mediaSource: MediaSource, resetPosition: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setMediaSource(mediaSource, resetPosition)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setMediaSource(mediaSource, resetPosition)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun addMediaSource(mediaSource: MediaSource): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaSource(mediaSource)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaSource(mediaSource)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun addMediaSource(index: Int, mediaSource: MediaSource): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaSource(index, mediaSource)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaSource(index, mediaSource)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun addMediaSources(mediaSources: MutableList<MediaSource>): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaSources(mediaSources)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaSources(mediaSources)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun addMediaSources(index: Int, mediaSources: MutableList<MediaSource>): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.addMediaSources(index, mediaSources)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.addMediaSources(index, mediaSources)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setShuffleOrder(shuffleOrder: ShuffleOrder): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setShuffleOrder(shuffleOrder)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setShuffleOrder(shuffleOrder)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun createMessage(target: PlayerMessage.Target): Promise<PlayerMessage> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.createMessage(target) },
-			handler)
+		handler.loopIn { innerPlayer.createMessage(target) }
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setSeekParameters(seekParameters: SeekParameters?): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setSeekParameters(seekParameters)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setSeekParameters(seekParameters)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getSeekParameters(): Promise<SeekParameters> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.seekParameters },
-			handler)
+		handler.loopIn { innerPlayer.seekParameters }
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setForegroundMode(foregroundMode: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.setForegroundMode(foregroundMode)
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.setForegroundMode(foregroundMode)
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun setPauseAtEndOfMediaItems(pauseAtEndOfMediaItems: Boolean): Promise<PromisingExoPlayer> =
-		LoopedInPromise(
-			MessageWriter {
-				innerPlayer.pauseAtEndOfMediaItems = pauseAtEndOfMediaItems
-				this
-			},
-			handler)
+		handler.loopIn {
+			innerPlayer.pauseAtEndOfMediaItems = pauseAtEndOfMediaItems
+			this
+		}
 
 	@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 	override fun getPauseAtEndOfMediaItems(): Promise<Boolean> =
-		LoopedInPromise(
-			MessageWriter { innerPlayer.pauseAtEndOfMediaItems },
-			handler)
+		handler.loopIn { innerPlayer.pauseAtEndOfMediaItems }
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/EmptyPlaybackHandler.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/EmptyPlaybackHandler.kt
@@ -1,12 +1,12 @@
 package com.lasthopesoftware.bluewater.client.playback.file
 
-import com.lasthopesoftware.bluewater.client.playback.file.buffering.IBufferingPlaybackFile
+import com.lasthopesoftware.bluewater.client.playback.file.buffering.BufferingPlaybackFile
 import com.lasthopesoftware.promises.extensions.ProgressedPromise
 import com.lasthopesoftware.promises.extensions.toPromise
 import com.namehillsoftware.handoff.promises.Promise
 import org.joda.time.Duration
 
-class EmptyPlaybackHandler(private val fileDuration: Int) : ProgressedPromise<Duration, PlayedFile>(), IBufferingPlaybackFile, PlayableFile, PlayingFile, PlayedFile {
+class EmptyPlaybackHandler(private val fileDuration: Int) : ProgressedPromise<Duration, PlayedFile>(), BufferingPlaybackFile, PlayableFile, PlayingFile, PlayedFile {
 	private val promisedThis: Promise<*> = this
 
 	init {
@@ -25,8 +25,8 @@ class EmptyPlaybackHandler(private val fileDuration: Int) : ProgressedPromise<Du
 	}
 
 	@Suppress("UNCHECKED_CAST")
-	override fun promiseBufferedPlaybackFile(): Promise<IBufferingPlaybackFile> {
-		return promisedThis as Promise<IBufferingPlaybackFile>
+	override fun promiseBufferedPlaybackFile(): Promise<BufferingPlaybackFile> {
+		return promisedThis as Promise<BufferingPlaybackFile>
 	}
 
 	@Suppress("UNCHECKED_CAST")

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/buffering/BufferingPlaybackFile.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/buffering/BufferingPlaybackFile.kt
@@ -2,6 +2,6 @@ package com.lasthopesoftware.bluewater.client.playback.file.buffering
 
 import com.namehillsoftware.handoff.promises.Promise
 
-interface IBufferingPlaybackFile {
-    fun promiseBufferedPlaybackFile(): Promise<IBufferingPlaybackFile>
+interface BufferingPlaybackFile {
+    fun promiseBufferedPlaybackFile(): Promise<BufferingPlaybackFile>
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/BufferingExoPlayer.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/BufferingExoPlayer.kt
@@ -18,7 +18,11 @@ import com.namehillsoftware.handoff.promises.response.ImmediateResponse
 import java.io.IOException
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-class BufferingExoPlayer(private val playbackHandler: Handler, private val handler: Handler, private val mediaSource: MediaSource, private val exoPlayer: PromisingExoPlayer) : Promise<BufferingPlaybackFile>(), BufferingPlaybackFile,
+class BufferingExoPlayer(
+	private val handler: Handler,
+	private val mediaSource: MediaSource,
+	private val exoPlayer: PromisingExoPlayer
+) : Promise<BufferingPlaybackFile>(), BufferingPlaybackFile,
 	MediaSourceEventListener, Player.Listener, MessageWriter<Unit>, Runnable, ImmediateResponse<Collection<Unit>, BufferingExoPlayer> {
 
 	companion object {
@@ -26,7 +30,7 @@ class BufferingExoPlayer(private val playbackHandler: Handler, private val handl
 	}
 
 	fun promiseSubscribedExoPlayer(): Promise<BufferingExoPlayer> = whenAll(
-		playbackHandler.loopIn(this),
+		handler.loopIn(this),
 		exoPlayer.addListener(this).unitResponse()
 	).then(this)
 

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/BufferingExoPlayerProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/BufferingExoPlayerProvider.kt
@@ -5,9 +5,9 @@ import androidx.media3.exoplayer.source.MediaSource
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.PromisingExoPlayer
 import com.namehillsoftware.handoff.promises.Promise
 
-class BufferingExoPlayerProvider(private val playbackHandler: Handler, private val handler: Handler) :
+class BufferingExoPlayerProvider(private val handler: Handler) :
 	ProvideBufferingExoPlayers {
 	override fun promiseBufferingExoPlayer(mediaSource: MediaSource, player: PromisingExoPlayer): Promise<BufferingExoPlayer> {
-		return BufferingExoPlayer(playbackHandler, handler, mediaSource, player).promiseSubscribedExoPlayer()
+		return BufferingExoPlayer(handler, mediaSource, player).promiseSubscribedExoPlayer()
 	}
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/BufferingExoPlayerProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/BufferingExoPlayerProvider.kt
@@ -1,0 +1,13 @@
+package com.lasthopesoftware.bluewater.client.playback.file.exoplayer.buffering
+
+import android.os.Handler
+import androidx.media3.exoplayer.source.MediaSource
+import com.lasthopesoftware.bluewater.client.playback.exoplayer.PromisingExoPlayer
+import com.namehillsoftware.handoff.promises.Promise
+
+class BufferingExoPlayerProvider(private val playbackHandler: Handler, private val handler: Handler) :
+	ProvideBufferingExoPlayers {
+	override fun promiseBufferingExoPlayer(mediaSource: MediaSource, player: PromisingExoPlayer): Promise<BufferingExoPlayer> {
+		return BufferingExoPlayer(playbackHandler, handler, mediaSource, player).promiseSubscribedExoPlayer()
+	}
+}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/ProvideBufferingExoPlayers.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/buffering/ProvideBufferingExoPlayers.kt
@@ -1,0 +1,9 @@
+package com.lasthopesoftware.bluewater.client.playback.file.exoplayer.buffering
+
+import androidx.media3.exoplayer.source.MediaSource
+import com.lasthopesoftware.bluewater.client.playback.exoplayer.PromisingExoPlayer
+import com.namehillsoftware.handoff.promises.Promise
+
+interface ProvideBufferingExoPlayers {
+	fun promiseBufferingExoPlayer(mediaSource: MediaSource, player: PromisingExoPlayer): Promise<BufferingExoPlayer>
+}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlayableFilePreparationSourceProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlayableFilePreparationSourceProvider.kt
@@ -15,7 +15,7 @@ import org.joda.time.Minutes
 @UnstableApi class ExoPlayerPlayableFilePreparationSourceProvider(
 	private val context: Context,
 	private val playbackHandler: Handler,
-	private val eventHandler: Handler,
+	private val interactionsHandler: Handler,
 	private val mediaSourceProvider: SpawnMediaSources,
 	private val bestMatchUriProvider: BestMatchUriProvider
 ) : IPlayableFilePreparationSourceProvider {
@@ -42,12 +42,13 @@ import org.joda.time.Minutes
 			context,
 			renderersFactory,
 			loadControl,
+			interactionsHandler,
 			playbackHandler
 		)
 	}
 
 	private val bufferingExoPlayerProvider by lazy {
-		BufferingExoPlayerProvider(playbackHandler, eventHandler)
+		BufferingExoPlayerProvider(interactionsHandler)
 	}
 
     override val maxQueueSize get() = 1

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlayableFilePreparationSourceProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlayableFilePreparationSourceProvider.kt
@@ -3,37 +3,21 @@ package com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparatio
 import android.content.Context
 import android.os.Handler
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.LoadControl
 import com.lasthopesoftware.bluewater.client.browsing.files.uri.BestMatchUriProvider
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.IPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.ExoPlayerProvider
 import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparation.mediasource.SpawnMediaSources
 import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.rendering.AudioRenderersFactory
-import org.joda.time.Minutes
 
 @UnstableApi class ExoPlayerPlayableFilePreparationSourceProvider(
 	private val context: Context,
+	private val loadControl: LoadControl,
 	private val playbackHandler: Handler,
 	private val eventHandler: Handler,
 	private val mediaSourceProvider: SpawnMediaSources,
 	private val bestMatchUriProvider: BestMatchUriProvider
 ) : IPlayableFilePreparationSourceProvider {
-
-	companion object {
-		private val maxBufferMs by lazy { Minutes.minutes(5).toStandardDuration().millis.toInt() }
-		private val loadControl by lazy {
-			val builder = DefaultLoadControl.Builder()
-			builder
-				.setBufferDurationsMs(
-					DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
-					maxBufferMs,
-					DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-					DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS)
-				.setPrioritizeTimeOverSizeThresholds(true)
-			builder.build()
-		}
-	}
-
 	private val renderersFactory = AudioRenderersFactory(context)
 
 	private val exoPlayerProvider by lazy {
@@ -50,6 +34,7 @@ import org.joda.time.Minutes
 	override fun providePlayableFilePreparationSource() = ExoPlayerPlaybackPreparer(
 		mediaSourceProvider,
 		exoPlayerProvider,
+		playbackHandler,
 		eventHandler,
 		bestMatchUriProvider
 	)

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlayableFilePreparationSourceProvider.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlayableFilePreparationSourceProvider.kt
@@ -3,22 +3,39 @@ package com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparatio
 import android.content.Context
 import android.os.Handler
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.LoadControl
+import androidx.media3.exoplayer.DefaultLoadControl
 import com.lasthopesoftware.bluewater.client.browsing.files.uri.BestMatchUriProvider
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.IPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.ExoPlayerProvider
+import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.buffering.BufferingExoPlayerProvider
 import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparation.mediasource.SpawnMediaSources
 import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.rendering.AudioRenderersFactory
+import org.joda.time.Minutes
 
 @UnstableApi class ExoPlayerPlayableFilePreparationSourceProvider(
 	private val context: Context,
-	private val loadControl: LoadControl,
 	private val playbackHandler: Handler,
 	private val eventHandler: Handler,
 	private val mediaSourceProvider: SpawnMediaSources,
 	private val bestMatchUriProvider: BestMatchUriProvider
 ) : IPlayableFilePreparationSourceProvider {
+	companion object {
+		private val maxBufferMs by lazy { Minutes.minutes(5).toStandardDuration().millis.toInt() }
+	}
+
 	private val renderersFactory = AudioRenderersFactory(context)
+
+	private val loadControl by lazy {
+		val builder = DefaultLoadControl.Builder()
+		builder
+			.setBufferDurationsMs(
+				DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
+				maxBufferMs,
+				DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+				DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS)
+			.setPrioritizeTimeOverSizeThresholds(true)
+		builder.build()
+	}
 
 	private val exoPlayerProvider by lazy {
 		ExoPlayerProvider(
@@ -29,13 +46,16 @@ import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.rendering.A
 		)
 	}
 
+	private val bufferingExoPlayerProvider by lazy {
+		BufferingExoPlayerProvider(playbackHandler, eventHandler)
+	}
+
     override val maxQueueSize get() = 1
 
 	override fun providePlayableFilePreparationSource() = ExoPlayerPlaybackPreparer(
 		mediaSourceProvider,
 		exoPlayerProvider,
-		playbackHandler,
-		eventHandler,
+		bufferingExoPlayerProvider,
 		bestMatchUriProvider
 	)
 }

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlaybackPreparer.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlaybackPreparer.kt
@@ -1,10 +1,10 @@
 package com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparation
 
-import android.os.Handler
 import com.lasthopesoftware.bluewater.client.browsing.files.ServiceFile
 import com.lasthopesoftware.bluewater.client.browsing.files.uri.ProvideFileUrisForLibrary
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.ProvideExoPlayers
+import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.buffering.ProvideBufferingExoPlayers
 import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparation.mediasource.SpawnMediaSources
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PlayableFilePreparationSource
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PreparedPlayableFile
@@ -15,8 +15,7 @@ import org.joda.time.Duration
 class ExoPlayerPlaybackPreparer(
 	private val mediaSourceProvider: SpawnMediaSources,
 	private val provideExoPlayers: ProvideExoPlayers,
-	private val playbackHandler: Handler,
-	private val eventHandler: Handler,
+	private val provideBufferingExoPlayers: ProvideBufferingExoPlayers,
 	private val uriProvider: ProvideFileUrisForLibrary
 ) : PlayableFilePreparationSource {
 
@@ -27,8 +26,7 @@ class ExoPlayerPlaybackPreparer(
 				uri?.let {
 					PreparedExoPlayerPromise(
 						mediaSourceProvider,
-						playbackHandler,
-						eventHandler,
+						provideBufferingExoPlayers,
 						provideExoPlayers,
 						libraryId,
 						it,

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlaybackPreparer.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/ExoPlayerPlaybackPreparer.kt
@@ -15,6 +15,7 @@ import org.joda.time.Duration
 class ExoPlayerPlaybackPreparer(
 	private val mediaSourceProvider: SpawnMediaSources,
 	private val provideExoPlayers: ProvideExoPlayers,
+	private val playbackHandler: Handler,
 	private val eventHandler: Handler,
 	private val uriProvider: ProvideFileUrisForLibrary
 ) : PlayableFilePreparationSource {
@@ -26,6 +27,7 @@ class ExoPlayerPlaybackPreparer(
 				uri?.let {
 					PreparedExoPlayerPromise(
 						mediaSourceProvider,
+						playbackHandler,
 						eventHandler,
 						provideExoPlayers,
 						libraryId,

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/preparation/PreparedPlayableFile.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/preparation/PreparedPlayableFile.kt
@@ -1,11 +1,11 @@
 package com.lasthopesoftware.bluewater.client.playback.file.preparation
 
 import com.lasthopesoftware.bluewater.client.playback.file.PlayableFile
-import com.lasthopesoftware.bluewater.client.playback.file.buffering.IBufferingPlaybackFile
+import com.lasthopesoftware.bluewater.client.playback.file.buffering.BufferingPlaybackFile
 import com.lasthopesoftware.bluewater.client.playback.file.volume.ManagePlayableFileVolume
 
 open class PreparedPlayableFile(
     val playbackHandler: PlayableFile,
     val playableFileVolumeManager: ManagePlayableFileVolume,
-    val bufferingPlaybackFile: IBufferingPlaybackFile
+    val bufferingPlaybackFile: BufferingPlaybackFile
 )

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/service/PlaybackService.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/service/PlaybackService.kt
@@ -19,7 +19,6 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
-import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlaybackException
 import com.lasthopesoftware.bluewater.ApplicationDependenciesContainer.applicationDependencies
 import com.lasthopesoftware.bluewater.R
@@ -147,7 +146,6 @@ import io.reactivex.rxjava3.internal.schedulers.ExecutorScheduler
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.joda.time.Duration
-import org.joda.time.Minutes
 import java.io.IOException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
@@ -175,8 +173,6 @@ import java.util.concurrent.TimeoutException
 		private val errorLatchResetDuration = Duration.standardSeconds(3)
 
 		private val playbackStartTimeout = Duration.standardMinutes(2)
-
-		private val maxBufferMs by lazy { Minutes.minutes(5).toStandardDuration().millis.toInt() }
 
 		fun initialize(context: Context, libraryId: LibraryId) =
 			context.safelyStartService(getNewSelfIntent(context, PlaybackEngineAction.Initialize(libraryId)))
@@ -604,15 +600,6 @@ import java.util.concurrent.TimeoutException
 				MaxFileVolumePreparationProvider(
 					ExoPlayerPlayableFilePreparationSourceProvider(
 						this,
-						DefaultLoadControl.Builder()
-							.setBufferDurationsMs(
-								DefaultLoadControl.DEFAULT_MIN_BUFFER_MS,
-								maxBufferMs,
-								DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-								DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS
-							)
-							.setPrioritizeTimeOverSizeThresholds(true)
-							.build(),
 						ph,
 						Handler(mainLooper),
 						MediaSourceProvider(

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/promises/extensions/LoopedInPromise.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/promises/extensions/LoopedInPromise.kt
@@ -125,5 +125,8 @@ open class LoopedInPromise<Result> : Promise<Result> {
 		fun act(task: ImmediateAction, handler: Handler): EventualAction {
 			return OneParameterExecutors.ReducingAction(task, handler)
 		}
+
+		fun <Resolution> Handler.loopIn(messageWriter: MessageWriter<Resolution>): Promise<Resolution> =
+			LoopedInPromise(messageWriter, this)
 	}
 }

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/preparation/GivenAStandardQueue/AndAFileThatFailsToBuffer/WhenTheQueueIsStarted.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/engine/preparation/GivenAStandardQueue/AndAFileThatFailsToBuffer/WhenTheQueueIsStarted.kt
@@ -3,7 +3,7 @@ package com.lasthopesoftware.bluewater.client.playback.engine.preparation.GivenA
 import com.lasthopesoftware.bluewater.client.browsing.files.ServiceFile
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.PreparedPlayableFileQueue
-import com.lasthopesoftware.bluewater.client.playback.file.buffering.IBufferingPlaybackFile
+import com.lasthopesoftware.bluewater.client.playback.file.buffering.BufferingPlaybackFile
 import com.lasthopesoftware.bluewater.client.playback.file.fakes.FakeBufferingPlaybackHandler
 import com.lasthopesoftware.bluewater.client.playback.file.fakes.FakePreparedPlayableFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PlayableFilePreparationSource
@@ -28,7 +28,7 @@ class WhenTheQueueIsStarted {
 		val playbackPreparer = mockk<PlayableFilePreparationSource>().apply {
 			every { promisePreparedPlaybackFile(LibraryId(libraryId), ServiceFile(0), Duration.ZERO) } returns Promise(
 				FakePreparedPlayableFile<FakeBufferingPlaybackHandler>(object : FakeBufferingPlaybackHandler() {
-					override fun promiseBufferedPlaybackFile(): Promise<IBufferingPlaybackFile> =
+					override fun promiseBufferedPlaybackFile(): Promise<BufferingPlaybackFile> =
 						Promise(IOException())
 				})
 			)

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/AndItIsDueToEndOfStream/WhenPreparing.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/AndItIsDueToEndOfStream/WhenPreparing.kt
@@ -11,6 +11,7 @@ import com.lasthopesoftware.bluewater.client.browsing.library.repository.Library
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.PromisingExoPlayer
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.ProvideExoPlayers
 import com.lasthopesoftware.bluewater.client.playback.file.EmptyPlaybackHandler
+import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.buffering.BufferingExoPlayer
 import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparation.ExoPlayerPlaybackPreparer
 import com.lasthopesoftware.bluewater.shared.cls
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -48,7 +49,16 @@ class WhenPreparing {
 					every { release() } returns selfPromise
 				}
 			},
-			mockk(),
+			mockk {
+				every { promiseBufferingExoPlayer(any(), any()) } answers {
+					BufferingExoPlayer(
+						mockk(),
+						mockk(),
+						firstArg(),
+						secondArg()
+					).toPromise()
+				}
+			},
 			mockk {
 				every { promiseUri(LibraryId(libraryId), ServiceFile(1)) } returns Promise(mockk<Uri>())
 			}

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/AndItIsDueToEndOfStream/WhenPreparing.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/AndItIsDueToEndOfStream/WhenPreparing.kt
@@ -52,11 +52,10 @@ class WhenPreparing {
 			mockk {
 				every { promiseBufferingExoPlayer(any(), any()) } answers {
 					BufferingExoPlayer(
-						mockk(),
-						mockk(),
-						firstArg(),
-						secondArg()
-					).toPromise()
+                        mockk(),
+                        firstArg(),
+                        secondArg()
+                    ).toPromise()
 				}
 			},
 			mockk {

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/WhenPreparing.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/WhenPreparing.kt
@@ -52,11 +52,10 @@ class WhenPreparing {
 			mockk {
 				every { promiseBufferingExoPlayer(any(), any()) } answers {
 					BufferingExoPlayer(
-						mockk(),
-						mockk(),
-						firstArg(),
-						secondArg()
-					).toPromise()
+                        mockk(),
+                        firstArg(),
+                        secondArg()
+                    ).toPromise()
 				}
 			},
 			mockk {

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/WhenPreparing.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/AndAProtocolErrorOccursDuringPreparation/WhenPreparing.kt
@@ -10,6 +10,7 @@ import com.lasthopesoftware.bluewater.client.browsing.files.ServiceFile
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.PromisingExoPlayer
 import com.lasthopesoftware.bluewater.client.playback.exoplayer.ProvideExoPlayers
+import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.buffering.BufferingExoPlayer
 import com.lasthopesoftware.bluewater.client.playback.file.exoplayer.preparation.ExoPlayerPlaybackPreparer
 import com.lasthopesoftware.bluewater.shared.cls
 import com.lasthopesoftware.bluewater.shared.promises.extensions.toExpiringFuture
@@ -48,7 +49,16 @@ class WhenPreparing {
 					every { release() } returns selfPromise
 				}
 			},
-			mockk(),
+			mockk {
+				every { promiseBufferingExoPlayer(any(), any()) } answers {
+					BufferingExoPlayer(
+						mockk(),
+						mockk(),
+						firstArg(),
+						secondArg()
+					).toPromise()
+				}
+			},
 			mockk {
 				every { promiseUri(LibraryId(libraryId), ServiceFile(1)) } returns Promise(mockk<Uri>())
 			}

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/WhenPreparing.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/WhenPreparing.kt
@@ -49,11 +49,10 @@ class WhenPreparing {
 			mockk {
 				every { promiseBufferingExoPlayer(any(), any()) } answers {
 					BufferingExoPlayer(
-						mockk(),
-						mockk(),
-						firstArg(),
-						secondArg()
-					).toPromise()
+                        mockk(),
+                        firstArg(),
+                        secondArg()
+                    ).toPromise()
 				}
 			},
 			mockk {

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/WhenPreparing.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/preparation/GivenUris/WhenPreparing.kt
@@ -46,7 +46,16 @@ class WhenPreparing {
 					every { release() } returns selfPromise
 				}
 			},
-			mockk(),
+			mockk {
+				every { promiseBufferingExoPlayer(any(), any()) } answers {
+					BufferingExoPlayer(
+						mockk(),
+						mockk(),
+						firstArg(),
+						secondArg()
+					).toPromise()
+				}
+			},
 			mockk {
 				every { promiseUri(LibraryId(libraryId), ServiceFile(1)) } returns Promise(mockk<Uri>())
 			}

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/fakes/FakeBufferingPlaybackHandler.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/fakes/FakeBufferingPlaybackHandler.kt
@@ -3,14 +3,14 @@ package com.lasthopesoftware.bluewater.client.playback.file.fakes
 import com.lasthopesoftware.bluewater.client.playback.file.PlayableFile
 import com.lasthopesoftware.bluewater.client.playback.file.PlayedFile
 import com.lasthopesoftware.bluewater.client.playback.file.PlayingFile
-import com.lasthopesoftware.bluewater.client.playback.file.buffering.IBufferingPlaybackFile
+import com.lasthopesoftware.bluewater.client.playback.file.buffering.BufferingPlaybackFile
 import com.lasthopesoftware.promises.extensions.ProgressedPromise
 import com.lasthopesoftware.promises.extensions.ProgressingPromise
 import com.lasthopesoftware.promises.extensions.toPromise
 import com.namehillsoftware.handoff.promises.Promise
 import org.joda.time.Duration
 
-open class FakeBufferingPlaybackHandler : IBufferingPlaybackFile, PlayableFile, PlayingFile, PlayedFile {
+open class FakeBufferingPlaybackHandler : BufferingPlaybackFile, PlayableFile, PlayingFile, PlayedFile {
 	private val playingStates = mutableListOf(false)
 
 	val recordedPlayingStates
@@ -37,7 +37,7 @@ open class FakeBufferingPlaybackHandler : IBufferingPlaybackFile, PlayableFile, 
 		isClosed = true
 	}
 
-	override fun promiseBufferedPlaybackFile(): Promise<IBufferingPlaybackFile> {
+	override fun promiseBufferedPlaybackFile(): Promise<BufferingPlaybackFile> {
 		return Promise(this)
 	}
 

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/fakes/FakePreparedPlayableFile.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/fakes/FakePreparedPlayableFile.kt
@@ -2,7 +2,7 @@ package com.lasthopesoftware.bluewater.client.playback.file.fakes
 
 import com.lasthopesoftware.bluewater.client.playback.file.NoTransformVolumeManager
 import com.lasthopesoftware.bluewater.client.playback.file.PlayableFile
-import com.lasthopesoftware.bluewater.client.playback.file.buffering.IBufferingPlaybackFile
+import com.lasthopesoftware.bluewater.client.playback.file.buffering.BufferingPlaybackFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PreparedPlayableFile
 
 class FakePreparedPlayableFile<PlaybackHandler>(playbackHandler: PlaybackHandler) :
@@ -10,4 +10,4 @@ class FakePreparedPlayableFile<PlaybackHandler>(playbackHandler: PlaybackHandler
         playbackHandler,
         NoTransformVolumeManager(),
         playbackHandler
-    ) where PlaybackHandler : PlayableFile, PlaybackHandler : IBufferingPlaybackFile
+    ) where PlaybackHandler : PlayableFile, PlaybackHandler : BufferingPlaybackFile

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/volume/preparation/FakeFilePreparer.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/volume/preparation/FakeFilePreparer.kt
@@ -4,13 +4,13 @@ import com.lasthopesoftware.bluewater.client.browsing.files.ServiceFile
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
 import com.lasthopesoftware.bluewater.client.playback.file.NoTransformVolumeManager
 import com.lasthopesoftware.bluewater.client.playback.file.PlayableFile
-import com.lasthopesoftware.bluewater.client.playback.file.buffering.IBufferingPlaybackFile
+import com.lasthopesoftware.bluewater.client.playback.file.buffering.BufferingPlaybackFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PlayableFilePreparationSource
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PreparedPlayableFile
 import com.namehillsoftware.handoff.promises.Promise
 import org.joda.time.Duration
 
-class FakeFilePreparer(private val playableFile: PlayableFile, private val bufferingPlaybackFile: IBufferingPlaybackFile) : PlayableFilePreparationSource {
+class FakeFilePreparer(private val playableFile: PlayableFile, private val bufferingPlaybackFile: BufferingPlaybackFile) : PlayableFilePreparationSource {
 	override fun promisePreparedPlaybackFile(libraryId: LibraryId, serviceFile: ServiceFile, preparedAt: Duration): Promise<PreparedPlayableFile?> =
 		Promise(PreparedPlayableFile(
 			playableFile,

--- a/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/volume/preparation/GivenABasePreparationSourceProvider/WhenGettingAPreparationSource.kt
+++ b/projectBlueWater/src/test/java/com/lasthopesoftware/bluewater/client/playback/file/volume/preparation/GivenABasePreparationSourceProvider/WhenGettingAPreparationSource.kt
@@ -2,7 +2,7 @@ package com.lasthopesoftware.bluewater.client.playback.file.volume.preparation.G
 
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.IPlayableFilePreparationSourceProvider
 import com.lasthopesoftware.bluewater.client.playback.file.EmptyPlaybackHandler
-import com.lasthopesoftware.bluewater.client.playback.file.buffering.IBufferingPlaybackFile
+import com.lasthopesoftware.bluewater.client.playback.file.buffering.BufferingPlaybackFile
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PlayableFilePreparationSource
 import com.lasthopesoftware.bluewater.client.playback.file.preparation.PreparedPlayableFile
 import com.lasthopesoftware.bluewater.client.playback.file.volume.preparation.MaxFileVolumePreparationProvider
@@ -21,9 +21,9 @@ class WhenGettingAPreparationSource {
                         Promise(PreparedPlayableFile(
                             EmptyPlaybackHandler(0),
                             mockk(),
-                            object : IBufferingPlaybackFile {
-                                override fun promiseBufferedPlaybackFile(): Promise<IBufferingPlaybackFile> {
-                                    return Promise<IBufferingPlaybackFile>(this)
+                            object : BufferingPlaybackFile {
+                                override fun promiseBufferedPlaybackFile(): Promise<BufferingPlaybackFile> {
+                                    return Promise<BufferingPlaybackFile>(this)
                                 }
                             }
                         ))


### PR DESCRIPTION
ExoPlayer has added a stringent requirement that load control be coupled to the player thread, which it seemingly doesn't correctly construct internally.