### PR TITLE
[Bugfix] Github releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,11 +14,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        fetch-depth: 0
     - name: Build and test project blue
       env:
         ANDROID_KEY_STORE_PASSWORD: "${{ secrets.ANDROID_KEY_STORE_PASSWORD }}"
         ANDROID_STORE_PASSWORD: "${{ secrets.ANDROID_STORE_PASSWORD }}"
-      run: sh build-release.sh
+      run: bash build-github-release.sh
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
@@ -30,7 +32,7 @@ jobs:
     name: Create release and upload artifacts
     needs:
       - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -42,4 +44,4 @@ jobs:
         run: |
           wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
           chmod +x pyuploadtool-x86_64.AppImage
-          ./pyuploadtool-x86_64.AppImage **/*.apk
+          ./pyuploadtool-x86_64.AppImage **/*-release.apk

--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ Run the tests via the IDE.
 Android Studio can perform the build. To run a CI build like it is run in Github, run the following command:
 
 ```shell script
-./build-release.sh
+./build-github-pr.sh
 ```
+
+This will leave artifacts that are owned by the root user. To run a build that leaves artifacts
+owned by the current user, run either `./build-release.sh` or `./build-apk.sh`.
 
 ## Deployment
 

--- a/build-github-release.sh
+++ b/build-github-release.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+shopt -s globstar
+shopt -s nullglob
+
+# Do not set user (`-u "$(id -u)":"$(id -g)"`) because it fails during Github actions. This means that
+# running this on a local machine will leave artifacts that have root ownership.
+
+docker compose build && docker compose run --rm \
+  -v "$(pwd)":/src -w /src \
+#  -u "$(id -u)":"$(id -g)" \
+   gradle \
+  :projectBlueWater:testReleaseUnitTest \
+  :projectBlueWater:assembleRelease
+
+mkdir -p _artifacts
+
+cp "$(pwd)"/projectBlueWater/build/**/*.apk "$(pwd)"/_artifacts/

--- a/build-release.sh
+++ b/build-release.sh
@@ -6,7 +6,9 @@ rm -rf _artifacts
 BUILD_USER=$(stat -c "%u" "$(pwd)")
 BUILD_GROUP=$(stat -c "%g" "$(pwd)")
 
-docker compose build && docker compose run --rm -v "$(pwd)":/src -w /src -u "$BUILD_USER":"$BUILD_GROUP" gradle \
+docker compose build && docker compose run --rm \
+  -v "$(pwd)":/src -w /src \
+  -u "$BUILD_USER":"$BUILD_GROUP" gradle \
   :projectBlueWater:testReleaseUnitTest \
   :projectBlueWater:assembleRelease \
   :projectBlueWater:bundleRelease


### PR DESCRIPTION
- Create artifacts directory if it does not exist
- Run script using bash
- Added nullglob option
- Fetch full commit history during build
- Split GitHub releases from other releases
- Ran artifact upload on Ubuntu 20.04
- Copied only release APK during build