### PR TITLE
[Bugfix] Empty Connection Settings

### DIFF
--- a/projectBlueWater/build.gradle
+++ b/projectBlueWater/build.gradle
@@ -199,7 +199,7 @@ dependencies {
 	implementation "androidx.media3:media3-datasource-okhttp:$media3_version"
 	implementation 'com.squareup.okio:okio:3.10.2'
 	implementation 'com.squareup.okhttp3:okhttp:5.0.0-alpha.14'
-	implementation 'com.namehillsoftware:querydroid:0.5.0'
+	implementation 'com.namehillsoftware:querydroid:0.5.2'
 	implementation "androidx.compose.ui:ui:$compose_version"
 	implementation "androidx.compose.material:material:$compose_version"
 	implementation "androidx.compose.ui:ui-tooling:$compose_version"

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/library/access/LibraryRepository.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/browsing/library/access/LibraryRepository.kt
@@ -103,20 +103,17 @@ class LibraryRepository(private val context: Context) : ManageLibraries, Provide
 			if (cancellationSignal.isCancelled) throw CancellationException("Cancelled while saving library")
 
 			return RepositoryAccessHelper(context).use { repositoryAccessHelper ->
-				repositoryAccessHelper.beginTransaction().use { closeableTransaction ->
-					val isLibraryExists = library.id > -1
+				val isLibraryExists = library.id > -1
 
-					val returnLibrary =
-						if (isLibraryExists) repositoryAccessHelper.update(tableName, library)
-						else repositoryAccessHelper.insert(tableName, library)
+				val returnLibrary =
+					if (isLibraryExists) repositoryAccessHelper.update(tableName, library)
+					else repositoryAccessHelper.insert(tableName, library)
 
-					if (BuildConfig.DEBUG) {
-						logger.debug("Library saved.")
-					}
-
-					closeableTransaction.setTransactionSuccessful()
-					returnLibrary
+				if (BuildConfig.DEBUG) {
+					logger.debug("Library saved.")
 				}
+
+				returnLibrary
 			}
 		}
 	}
@@ -137,18 +134,14 @@ class LibraryRepository(private val context: Context) : ManageLibraries, Provide
 			if (libraryInt < 0) return
 
 			RepositoryAccessHelper(context).use { repositoryAccessHelper ->
-				repositoryAccessHelper.beginTransaction().use { closeableTransaction ->
-					val result = SqLiteAssistants.updateValue(repositoryAccessHelper.writableDatabase, tableName, values)
+				val result = SqLiteAssistants.updateValue(repositoryAccessHelper.writableDatabase, tableName, values)
 
-					if (result == 0L) {
-						throw IOException("Updating $tableName for id ${values.id} returned 0 rows.")
-					}
+				if (result == 0L) {
+					throw IOException("Updating $tableName for id ${values.id} returned 0 rows.")
+				}
 
-					if (BuildConfig.DEBUG) {
-						logger.debug("Now Playing updated for library {}.", libraryInt)
-					}
-
-					closeableTransaction.setTransactionSuccessful()
+				if (BuildConfig.DEBUG) {
+					logger.debug("Now Playing updated for library {}.", libraryInt)
 				}
 			}
 		}

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/engine/PlaybackEngine.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/engine/PlaybackEngine.kt
@@ -1,6 +1,5 @@
 package com.lasthopesoftware.bluewater.client.playback.engine
 
-import androidx.lifecycle.AtomicReference
 import com.lasthopesoftware.bluewater.client.browsing.files.ServiceFile
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
 import com.lasthopesoftware.bluewater.client.playback.engine.bootstrap.BootstrapPlayback
@@ -35,6 +34,7 @@ import com.namehillsoftware.handoff.promises.Promise
 import org.jetbrains.annotations.Contract
 import org.joda.time.Duration
 import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.max
 
 class PlaybackEngine(

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/engine/bootstrap/ManagedPlaylistPlayer.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/engine/bootstrap/ManagedPlaylistPlayer.kt
@@ -1,6 +1,5 @@
 package com.lasthopesoftware.bluewater.client.playback.engine.bootstrap
 
-import androidx.lifecycle.AtomicReference
 import com.lasthopesoftware.bluewater.client.browsing.library.repository.LibraryId
 import com.lasthopesoftware.bluewater.client.playback.engine.preparation.ManagePlaybackQueues
 import com.lasthopesoftware.bluewater.client.playback.file.PositionedPlayableFile
@@ -18,6 +17,7 @@ import com.lasthopesoftware.promises.extensions.toPromise
 import com.lasthopesoftware.resources.closables.PromisingCloseable
 import com.namehillsoftware.handoff.promises.Promise
 import org.joda.time.Duration
+import java.util.concurrent.atomic.AtomicReference
 
 class ManagedPlaylistPlayer(
 	private val volumeManagement: PlaylistVolumeManager,

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/ExoPlayerPlaybackHandler.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/client/playback/file/exoplayer/ExoPlayerPlaybackHandler.kt
@@ -1,7 +1,6 @@
 package com.lasthopesoftware.bluewater.client.playback.file.exoplayer
 
 import androidx.annotation.OptIn
-import androidx.lifecycle.AtomicReference
 import androidx.media3.common.ParserException
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -24,6 +23,7 @@ import org.joda.time.Duration
 import org.joda.time.format.PeriodFormatterBuilder
 import java.io.EOFException
 import java.net.ProtocolException
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.cancellation.CancellationException
 
 class ExoPlayerPlaybackHandler(private val exoPlayer: PromisingExoPlayer) :

--- a/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/android/ui/UiCalculations.kt
+++ b/projectBlueWater/src/main/java/com/lasthopesoftware/bluewater/shared/android/ui/UiCalculations.kt
@@ -1,11 +1,5 @@
 package com.lasthopesoftware.bluewater.shared.android.ui
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.gestures.AnchoredDraggableState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.Dp
 
 fun linearInterpolation(initial: Dp, final: Dp, progress: Float): Dp =
@@ -16,8 +10,3 @@ fun linearInterpolation(initial: Float, final: Float, progress: Float): Float =
 
 fun calculateProgress(initial: Float, final: Float, currentPosition: Float): Float =
 	((currentPosition - initial) / (final - initial)).coerceIn(0f, 1f)
-
-@OptIn(ExperimentalFoundationApi::class)
-val <T> AnchoredDraggableState<T>.absoluteProgressState: State<Float>
-	@Composable
-	get() = remember { derivedStateOf { (requireOffset() - anchors.minAnchor()) / anchors.maxAnchor() } }


### PR DESCRIPTION
Fix an issue with connection settings being emptied out. This was due to cache confusion in the Querydroid library, which has also been fixed (https://github.com/namehillsoftware/querydroid/pull/15).